### PR TITLE
v4.0.0 — fix CI hang, Opus 4.8 + correct pricing, Context Control Center

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "3.6.0",
-  "description": "Opus 4.7-aware context optimization: 1M-context tuning, prompt coach, smart context packs, ContextShield, CLAUDE.md analyzer, accurate token costs, MCP tool tracking",
+  "version": "4.0.0",
+  "description": "Opus 4.8-aware context optimization: 1M-context tuning, accurate token costs, prompt coach, smart context packs, ContextShield, CLAUDE.md analyzer, MCP tool tracking",
   "author": {
     "name": "Egor Fedorov"
   },
@@ -9,7 +9,7 @@
   "license": "MIT",
   "keywords": [
     "claude-code",
-    "claude-opus-4.7",
+    "claude-opus-4.8",
     "context-optimization",
     "token-tracking",
     "prompt-engineering",

--- a/README.md
+++ b/README.md
@@ -326,12 +326,15 @@ Run `/cco-export html` to generate a static HTML dashboard you can open in any b
 - Project breakdown doughnut
 - Edits-per-session timeline
 
-### Context Heatmap — see where your tokens go
+### Context Control Center — everything in one screen
 
-Run `/cco` to get a visual breakdown of every file in your session. Green = useful. Red = waste.
+Run `/cco` for the live board: budget %, $ spent, tokens saved by the cache (effectiveness
+multiplier), waste/cold files, last prompt grade, the active task's cost, and ready-to-run
+actions (what to drop → `/compact`, what to `/cco-pack`). Drill into the per-file heatmap —
+green = useful, red = waste — for detail.
 
 <p align="center">
-  <img src="assets/heatmap-demo.svg" alt="Context Heatmap" width="700"/>
+  <img src="assets/heatmap-demo.svg" alt="Context Control Center" width="700"/>
 </p>
 
 ### Token ROI Report — full analytics across sessions

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <strong>Stop burning tokens on weak prompts and redundant reads.</strong><br/>
-  <sub>Tuned for Claude Opus 4.7 — including the 1M-context tier.</sub>
+  <sub>Tuned for Claude Opus 4.8 — full 1M context at standard price.</sub>
 </p>
 
 <p align="center">
@@ -25,7 +25,7 @@ The average Claude Code session **wastes 30-50% of tokens** on files that are re
 - A README you glanced at once? **2,400 tokens burned.**
 - That `package.json` Claude reads "just in case"? **120 tokens, every time.**
 
-At $15/M tokens (Opus), a developer spending $100/month is lighting **$30-50 on fire** on irrelevant context.
+At $5/M input tokens (Opus 4.8), a developer spending $100/month is lighting **$30-50 on fire** on irrelevant context.
 
 ## The Solution
 
@@ -34,6 +34,74 @@ At $15/M tokens (Opus), a developer spending $100/month is lighting **$30-50 on 
 <p align="center">
   <img src="assets/how-it-works.svg" alt="How it works" width="700"/>
 </p>
+
+---
+
+## What's new in v4.0 — Opus 4.8
+
+v4.0 makes the plugin **Opus 4.8-aware**, adds a flagship **Context Control Center**,
+and corrects the model facts.
+
+### NEW: Context Control Center — everything in one screen (`/cco`)
+
+`/cco` is now a single, live dashboard instead of just a heatmap:
+
+```
+  CONTEXT CONTROL CENTER          opus-4.8 · 1M
+  ────────────────────────────────────────────────────────────
+  Budget   ▓▓▓▓▓▓▓░░░  142K / 200K  (71%)  $0.84
+  Saved    +58K tokens by cache  →  1.41x effective  (12 reads blocked)
+  Waste    ▓▓░░░░░░░░  18%  (3 cold files)
+  Prompt   last grade: B  (add a file path to be specific)
+  ────────────────────────────────────────────────────────────
+  ▶ Task   #4 refactor login flow  ·  ~31K · $0.155
+  ✓ #3 add OAuth provider  ·  ~22K
+  ────────────────────────────────────────────────────────────
+  ⚡ Free ~22K:  drop legacy/old_api.ts, vendor/build.js  → /compact
+  📦 Pack minimal context:  /cco-pack "refactor login flow"
+```
+
+One screen ties together **budget %, $ spent, tokens saved (effectiveness
+multiplier), waste, last prompt grade, the active task's cost, and ready-to-run
+actions** — all from data the optimizer already tracks. Nothing to configure.
+
+### NEW: Organize work by task (`/cco-task`)
+
+Track tokens and cost **per task**, not just per session:
+
+```bash
+$ /cco-task add "refactor login flow"   # start a task
+$ /cco-pack "refactor login flow"        # load only the files it needs
+  …work…
+$ /cco-task done                         # freezes the task's token/$ total
+```
+
+While a task is active, session tokens are attributed to it, so `/cco` shows
+exactly what each task costs. One active task per project; starting a new one
+finalizes the previous one automatically.
+
+### NEW: Auto-Optimizer session report
+
+At session end the optimizer prints what it saved you:
+
+```
+  CCO saved you 71K tokens this session (~$0.36).
+  Your 200K budget worked like 271K (1.36x).
+```
+
+### Model & correctness updates
+
+- **Opus 4.8 is now the default model** (`opus-4.8`). Opus 4.7 is still fully supported.
+- **Pricing corrected:** Opus 4.7/4.8 are **$5/M input, $25/M output** — and deliver the
+  **full 1M context window at that standard price**. There is **no 1M "premium tier" and no
+  surcharge**. The old `opus-4.7-1m` $22.50/$112.50 claim was wrong and has been removed;
+  `opus-4.7-1m` / `opus-4.8-1m` / `opus-extended` remain only as back-compat aliases that now
+  map to the standard $5/$25 1M Opus.
+- **Sonnet 4.6 is now 1M context** ($3/M input, $15/M output) — previously mislabelled 200K.
+  Haiku 4.5 stays 200K ($1/$5).
+- **CI/test fix:** hook modules used to read stdin on import, which hung the test suite
+  (v3.6.0 CI runs timed out at 6h). The stdin-reading `main()` is now guarded with
+  `isMainModule()`, so importing a hook for unit testing no longer blocks.
 
 ---
 
@@ -83,18 +151,19 @@ $ /cco-pack "refactor login flow to support OAuth"
 ```
 
 Mentioned files + git diff + historical patterns + keyword match → ranked, token-budget aware.
-Stops at 25% of your effective context. With Opus 4.7 1M that's 250K of "safe to load now".
+Stops at 25% of your effective context. With Opus 4.8's 1M window that's 250K of "safe to load now".
 
-### NEW: 1M context tier support — `opus-4.7-1m`
+### NEW: 1M context support — standard on Opus
 
 ```bash
-/cco-budget model opus-4.7-1m
+/cco-budget model opus-4.8
 ```
 
-Switching models retunes the entire plugin:
+Opus 4.7/4.8 deliver the full 1M window at the standard $5/$25 price — no premium tier, no
+surcharge. Switching models still retunes the entire plugin:
 - **Read Cache staleness thresholds scale** — 100K/40-files/10min instead of 20K/8-files/10min,
   so you don't get false re-reads in massive contexts.
-- **Cost calculation uses 1M-tier prices** — $22.50/M input, $112.50/M output.
+- **Cost calculation uses each model's real prices** — Opus $5/$25, Sonnet 4.6 $3/$15, Haiku 4.5 $1/$5.
 - **Budget warnings stop firing at 5%** of a 1M window — they fire at the percentages of *your*
   effective budget.
 
@@ -111,10 +180,10 @@ in token reports alongside Read/Edit/Write.
 ### NEW: `/cco-doctor` — health check
 
 ```
-✔ versions in sync (plugin.json vs package.json) — v3.6.0
+✔ versions in sync (plugin.json vs package.json) — v4.0.0
 ✔ hooks.json is valid JSON                       — 6 event types wired
 ✔ data directory writable                        — ~/.claude-context-optimizer
-✔ user config                                    — model=opus-4.7, budget=200.0K, window=200.0K
+✔ user config                                    — model=opus-4.8, budget=200.0K, window=1.0M
 ```
 
 Catches the "installed but nothing happens" class of issues in under a second.
@@ -317,7 +386,8 @@ When installed as a plugin, commands are namespaced: `/claude-context-optimizer:
 
 | Command | Description |
 |---------|-------------|
-| `/cco` | Session heatmap — visual file-by-file token breakdown |
+| `/cco` | **Context Control Center** — one screen: budget, $ spent, tokens saved, waste, prompt grade, active task, actions |
+| `/cco-task [add\|list\|done]` | **NEW** — organize work by task; tracks tokens + $ per task |
 | `/cco-report` | Full ROI report — stats, trends, waste analysis, recommendations |
 | `/cco-digest [days]` | Efficiency digest — score, grade, cost analysis (default: 7 days) |
 | `/cco-budget [status\|set\|model\|auto]` | Token budget — configure limits, cost model, auto-compact |
@@ -466,7 +536,9 @@ Tokens are estimated using extension-specific ratios (e.g., 3.8 chars/token for 
 ├── templates/          # User-defined context templates
 ├── exports/            # Exported reports (MD/HTML)
 ├── read-cache/         # Per-session read cache state
+├── prompts/            # Per-session prompt grades (Prompt Coach)
 ├── config.json         # Budget and preference settings
+├── tasks.json          # Per-task register (tokens/$ per task)
 ├── patterns.json       # Cross-session file usage patterns
 └── global-stats.json   # Aggregate statistics
 ```
@@ -481,6 +553,8 @@ claude-context-optimizer/
 │   └── plugin.json          # Plugin manifest
 ├── src/
 │   ├── utils.js             # Shared: constants, classification, model costs, atomic JSON I/O
+│   ├── dashboard.js         # NEW — Context Control Center (one-screen board + session summary)
+│   ├── tasks.js             # NEW — per-task register (tokens/$ per task)
 │   ├── read-cache.js        # Smart Read Cache (adaptive 1M-aware staleness)
 │   ├── contextignore.js     # .contextignore: pattern-based file blocking
 │   ├── replay.js            # Session Replay: recent session summaries
@@ -497,7 +571,8 @@ claude-context-optimizer/
 │   ├── smart-pack.js        # NEW — Optimal file pack builder (git + history + keywords)
 │   └── doctor.js            # NEW — Health check CLI
 ├── skills/
-│   ├── cco/SKILL.md               # /cco — session heatmap
+│   ├── cco/SKILL.md               # /cco — Context Control Center (one-screen board)
+│   ├── cco-task/SKILL.md          # NEW — /cco-task — per-task tokens/$ tracking
 │   ├── cco-report/SKILL.md        # /cco-report — full ROI report
 │   ├── cco-digest/SKILL.md        # /cco-digest — efficiency digest
 │   ├── cco-budget/SKILL.md        # /cco-budget — budget manager
@@ -545,9 +620,11 @@ A: No. Hook scripts run asynchronously and typically complete in <10ms.
 **Q: How accurate are the token estimates?**
 A: They use a ~4 tokens/line heuristic. Not exact, but consistent across sessions for reliable trends.
 
-**Q: Can I use this with Claude Sonnet / Haiku / Opus 4.7 1M?**
-A: Yes. `/cco-budget model haiku-4.5` / `sonnet-4.6` / `opus-4.7` / `opus-4.7-1m` — each retunes
-context window, prices, and Read Cache staleness thresholds.
+**Q: Can I use this with Claude Sonnet / Haiku / Opus 4.7 / Opus 4.8?**
+A: Yes. `/cco-budget model haiku-4.5` / `sonnet-4.6` / `opus-4.7` / `opus-4.8` — each retunes
+context window, prices, and Read Cache staleness thresholds. Opus 4.7/4.8 and Sonnet 4.6 are all
+1M context; Haiku 4.5 is 200K. (`opus-4.7-1m` / `opus-4.8-1m` still work as back-compat aliases —
+1M is standard now, so there's no surcharge.)
 
 **Q: Does Prompt Coach call any LLM?**
 A: No. It uses deterministic local heuristics (regex + scoring). Zero API calls,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1191,6 +1191,27 @@
     </p>
     <div class="feature-grid">
       <div class="feature">
+        <div class="feature-icon blue">&#x1F4CA;</div>
+        <h3>Context Control Center</h3>
+        <p>
+          <code>/cco</code> is now <strong>one screen</strong>: budget %, $ spent this session,
+          tokens saved by the cache (your <strong>effectiveness multiplier</strong>), waste,
+          last prompt grade, the <strong>active task's cost</strong>, and ready-to-run actions
+          (what to drop &rarr; <code>/compact</code>, what to <code>/cco-pack</code>). Everything the
+          optimizer tracks, unified — nothing to configure.
+        </p>
+      </div>
+      <div class="feature">
+        <div class="feature-icon green">&#x2705;</div>
+        <h3>Organize work by task</h3>
+        <p>
+          <code>/cco-task add "fix login flow"</code> starts a task; tokens spent are
+          <strong>attributed to it</strong>, so you see cost <em>per task</em>, not just per session.
+          Pair with <code>/cco-pack</code> to load only what each task needs, then
+          <code>/cco-task done</code> freezes its total. A session-end report shows what CCO saved you.
+        </p>
+      </div>
+      <div class="feature">
         <div class="feature-icon purple">&#x1F3AF;</div>
         <h3>Prompt Coach</h3>
         <p>
@@ -1257,14 +1278,14 @@
     <div class="section-label">Commands</div>
     <h2>When you want to dig deeper</h2>
     <p style="color: var(--text-dim); max-width: 550px; font-size: 1.05rem;">
-      The plugin works automatically, but 17 commands are available for detailed insights.
+      The plugin works automatically, but 18 commands are available for detailed insights.
     </p>
 
     <div class="feature-grid">
       <div class="feature">
         <div class="feature-icon purple">&#x1F4CA;</div>
-        <h3>Context Heatmap</h3>
-        <p>Run <code>/cco</code> to see a visual breakdown of every file in your session. Green = useful. Red = waste. With actionable recommendations.</p>
+        <h3>Control Center &amp; Heatmap</h3>
+        <p>Run <code>/cco</code> for the one-screen Control Center, or drill into the per-file heatmap — green = useful, red = waste — with actionable recommendations.</p>
       </div>
       <div class="feature">
         <div class="feature-icon green">&#x1F4B0;</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Context Optimizer — 63% Fewer Tokens + Better Prompts for Claude Opus 4.7</title>
-<meta name="description" content="Tuned for Claude Opus 4.7 (200K & 1M context). Prompt Coach grades and improves your prompts. Smart Context Pack picks optimal files. Read Cache blocks redundant reads. 63% token savings, benchmarked.">
-<meta property="og:title" content="Context Optimizer — Opus 4.7 ready, 63% fewer tokens, better prompts">
+<title>Context Optimizer — 63% Fewer Tokens + Better Prompts for Claude Opus 4.8</title>
+<meta name="description" content="Tuned for Claude Opus 4.8 (full 1M context at standard price). Prompt Coach grades and improves your prompts. Smart Context Pack picks optimal files. Read Cache blocks redundant reads. 63% token savings, benchmarked.">
+<meta property="og:title" content="Context Optimizer — Opus 4.8 ready, 63% fewer tokens, better prompts">
 <meta property="og:description" content="Prompt Coach + Smart Pack + Read Cache. 1M context aware. Benchmarked at 63% savings. Zero telemetry, MIT.">
 <meta property="og:type" content="website">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔍</text></svg>">
@@ -836,10 +836,10 @@
   <div class="container">
     <div class="badge">
       <div class="badge-dot"></div>
-      v3.6.0 &middot; Opus 4.7 ready &middot; 1M context aware &middot; Benchmarked
+      v4.0.0 &middot; Opus 4.8 ready &middot; 1M context aware &middot; Benchmarked
     </div>
     <div class="hero-stat">63%</div>
-    <h1>fewer tokens. <span class="highlight">Sharper prompts.</span><br>Tuned for Opus 4.7.</h1>
+    <h1>fewer tokens. <span class="highlight">Sharper prompts.</span><br>Tuned for Opus 4.8.</h1>
     <p class="hero-sub">
       Read Cache blocks redundant reads. <strong>Prompt Coach</strong> grades and rewrites weak prompts before they cost you context.
       <strong>Smart Pack</strong> picks the optimal file set for your task. Adaptive to 200K and 1M context windows.
@@ -989,17 +989,17 @@
           <td class="money-big">$151</td>
         </tr>
         <tr>
-          <td class="model-name">Opus 4.6</td>
-          <td>$15.00</td>
-          <td class="money">$0.42</td>
-          <td class="money">$2.10</td>
-          <td class="money-big">$63</td>
-          <td class="money-big">$756</td>
+          <td class="model-name">Opus 4.8</td>
+          <td>$5.00</td>
+          <td class="money">$0.14</td>
+          <td class="money">$0.70</td>
+          <td class="money-big">$21</td>
+          <td class="money-big">$252</td>
         </tr>
       </tbody>
     </table>
 
-    <p class="roi-note">* Individual developer. For a team of 10 on Opus: <strong style="color:var(--green)">$7,560/year</strong> saved.</p>
+    <p class="roi-note">* Individual developer. For a team of 10 on Opus: <strong style="color:var(--green)">$2,520/year</strong> saved. Opus 4.8 delivers the full 1M context window at $5/$25 per M — no premium tier.</p>
 
     <!-- Context multiplier -->
     <div class="multiplier-grid" style="margin-top:48px;">
@@ -1029,7 +1029,7 @@
     <h2>Your tokens are leaking. Every session.</h2>
     <p style="color: var(--text-dim); max-width: 600px; font-size: 1.05rem;">
       Every <code style="background:var(--bg-code);padding:2px 6px;border-radius:4px;color:var(--green)">Read</code> call consumes context &mdash; whether the file was relevant or not.
-      At $15/M tokens on Opus, this adds up fast.
+      At $5/M input tokens on Opus 4.8, this adds up fast.
     </p>
 
     <!-- Token accumulation visualization -->
@@ -1178,14 +1178,16 @@
   </div>
 </section>
 
-<!-- New in 3.6 — Prompt Quality + 1M -->
-<section class="features" id="new-3-6" style="padding-top: 60px;">
+<!-- New in 4.0 — Opus 4.8 + Prompt Quality + 1M -->
+<section class="features" id="new-4-0" style="padding-top: 60px;">
   <div class="container">
-    <div class="section-label">New in v3.6 — Opus 4.7 update</div>
+    <div class="section-label">New in v4.0 — Opus 4.8</div>
     <h2>Save tokens <em>and</em> generate better answers</h2>
     <p style="color: var(--text-dim); max-width: 700px; font-size: 1.05rem;">
-      Optimization isn't just about blocking reads. The most expensive thing in any session is a vague prompt
-      that sends Claude reading 20 files to guess your intent. v3.6 adds two new ways to make every prompt count.
+      Opus 4.8-aware, with corrected model facts: Opus 4.7/4.8 deliver the full 1M window at the
+      standard $5/$25 price — no premium tier. Optimization isn't just about blocking reads, though:
+      the most expensive thing in any session is a vague prompt that sends Claude reading 20 files to
+      guess your intent. The Prompt Coach and Smart Pack make every prompt count.
     </p>
     <div class="feature-grid">
       <div class="feature">
@@ -1211,11 +1213,11 @@
       </div>
       <div class="feature">
         <div class="feature-icon yellow">&#x1F4A1;</div>
-        <h3>1M Context Tier</h3>
+        <h3>1M Context — Standard</h3>
         <p>
-          Set <code>/cco-budget model opus-4.7-1m</code> and the entire plugin retunes:
+          Set <code>/cco-budget model opus-4.8</code> and the entire plugin retunes:
           adaptive Read Cache staleness thresholds, correct cost calculations
-          ($22.50/$112.50 per M), and budget warnings that don't fire at 5% of a 1M window.
+          ($5/$25 per M — full 1M, no surcharge), and budget warnings that don't fire at 5% of a 1M window.
         </p>
       </div>
       <div class="feature">
@@ -1223,7 +1225,7 @@
         <h3>Real Cost Tracking</h3>
         <p>
           Budget monitor now estimates input <strong>and output</strong> tokens separately
-          and uses each model's real prices (Opus 4.7: $15/$75, Haiku 4.5: $1/$5).
+          and uses each model's real prices (Opus 4.8: $5/$25, Sonnet 4.6: $3/$15, Haiku 4.5: $1/$5).
           You see actual cost — not just half of it.
         </p>
       </div>

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -84,6 +84,10 @@
           {
             "type": "command",
             "command": "test -f \"${CLAUDE_PLUGIN_ROOT}/src/tracker.js\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/src/tracker.js\""
+          },
+          {
+            "type": "command",
+            "command": "test -f \"${CLAUDE_PLUGIN_ROOT}/src/dashboard.js\" || exit 0; node \"${CLAUDE_PLUGIN_ROOT}/src/dashboard.js\" summary"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "3.6.0",
-  "description": "Opus 4.7-aware context optimization: 1M-context tuning, prompt coach, smart context packs, ContextShield, CLAUDE.md analyzer, accurate token costs, MCP tool tracking",
+  "version": "4.0.0",
+  "description": "Opus 4.8-aware context optimization: 1M-context tuning, accurate token costs, prompt coach, smart context packs, ContextShield, CLAUDE.md analyzer, MCP tool tracking",
   "type": "module",
   "main": "src/tracker.js",
   "bin": {

--- a/skills/cco-budget/SKILL.md
+++ b/skills/cco-budget/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: cco-budget
-description: Configure token budget limits, auto-compact settings, and view current budget status (model-aware — supports Opus 4.7 1M context tier)
+description: Configure token budget limits, auto-compact settings, and view current budget status (model-aware — Opus 4.8 default, full 1M context at standard price)
 license: MIT
-argument-hint: "[status | set <tokens> | model <haiku|haiku-4.5|sonnet|sonnet-4.6|opus|opus-4.7|opus-4.7-1m> | auto <on|off>]"
+argument-hint: "[status | set <tokens> | model <haiku|haiku-4.5|sonnet|sonnet-4.6|opus|opus-4.7|opus-4.8> | auto <on|off>]"
 allowed-tools: [Bash, Read, Write]
 ---
 
 # Context Budget Manager
 
 Manage the token budget for Claude Code sessions. Now model-aware — picks the
-right effective context window for Opus 4.7 (200K) vs Opus 4.7 1M (1M).
+right effective context window per model. Opus 4.7/4.8 and Sonnet 4.6 are all 1M;
+Haiku 4.5 is 200K.
 
 Parse $ARGUMENTS:
 
@@ -20,7 +21,7 @@ cat ~/.claude-context-optimizer/config.json 2>/dev/null
 echo "---"
 cat ~/.claude-context-optimizer/budget-config.json 2>/dev/null
 ```
-If no config exists, show defaults (200K tokens for Opus 4.7, warn at 50/70/85/95%).
+If no config exists, show defaults (200K working budget on Opus 4.8's 1M window, warn at 50/70/85/95%).
 
 ## `set <tokens>`
 Update the budget limit. Parse the token count (`200K`, `1M`, `500000` all OK).
@@ -30,7 +31,7 @@ Update `~/.claude-context-optimizer/config.json`:
   "budgetTokens": <parsed_number>,
   "warnAt": [50, 70, 85, 95],
   "autoCompactAt": 90,
-  "model": "opus-4.7"
+  "model": "opus-4.8"
 }
 ```
 If `budgetTokens` exceeds the chosen model's context window, warn the user.
@@ -38,11 +39,14 @@ If `budgetTokens` exceeds the chosen model's context window, warn the user.
 ## `model <name>`
 Set the model for cost estimation. Supported keys:
 - `haiku-4.5` (alias `haiku`) — $1/$5 per M, 200K
-- `sonnet-4.6` (alias `sonnet`) — $3/$15 per M, 200K
-- `opus-4.7` (alias `opus`) — $15/$75 per M, 200K
-- `opus-4.7-1m` — $22.50/$112.50 per M, **1M** context window
+- `sonnet-4.6` (alias `sonnet`) — $3/$15 per M, **1M**
+- `opus-4.7` — $5/$25 per M, **1M**
+- `opus-4.8` (alias `opus`, **default**) — $5/$25 per M, **1M**
 
-Update the `model` field in config.json. If switching to `opus-4.7-1m` and the
+`opus-4.8-1m` / `opus-4.7-1m` / `opus-extended` are back-compat aliases only — there is
+no 1M surcharge; the 1M window is standard at $5/$25.
+
+Update the `model` field in config.json. When switching to a 1M-context model and the
 current `budgetTokens` is below 500K, ask if the user wants to bump it to 1M.
 
 ## `auto <on|off>`

--- a/skills/cco-doctor/SKILL.md
+++ b/skills/cco-doctor/SKILL.md
@@ -38,7 +38,7 @@ node ${CLAUDE_PLUGIN_ROOT}/src/doctor.js --tests
 Translate the doctor output into plain language. If anything is `fail`, walk the user through the fix:
 - versions out of sync → `npm run sync-version`
 - patterns.json too big → `/cco-clean`
-- budget > model window → `/cco-budget set <smaller>` or pick a 1M-context model
+- budget > model window → `/cco-budget set <smaller>` or pick a 1M-context model (e.g. `opus-4.8`)
 - node too old → upgrade Node
 
 If everything is `pass`, confirm "плагин в порядке, текущая версия Х.Y.Z" and stop.

--- a/skills/cco-pack/SKILL.md
+++ b/skills/cco-pack/SKILL.md
@@ -37,7 +37,7 @@ For each file the pack also suggests `offset` / `limit` — pointing at the stru
 
 ## Token budget awareness
 
-Pack stops adding files once it would exceed 25% of the user's effective context budget. The budget itself respects the configured model (e.g. 1M for `opus-4.7-1m`).
+Pack stops adding files once it would exceed 25% of the user's effective context budget. The budget itself respects the configured model (e.g. the full 1M window for `opus-4.8` — 1M is standard on Opus, no premium tier).
 
 ## Presentation
 

--- a/skills/cco-task/SKILL.md
+++ b/skills/cco-task/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cco-task
+description: Organize work by task and track tokens/cost per task — start a task, list tasks, or mark the active one done. Pairs with /cco-pack to load minimal context per task.
+license: MIT
+argument-hint: "[add \"<name>\" | list | done [note]]"
+allowed-tools: [Bash]
+---
+
+# Tasks — per-task context & cost
+
+A task is a named unit of work. While a task is active, the tokens the session
+spends are attributed to it, so the Control Center (`/cco`) can show cost **per
+task**, not just per session. This is how the optimizer helps you *distribute
+work by task* while keeping token spend visible and low.
+
+## Commands
+
+Parse the user's argument and run the matching command (working directory scopes
+the tasks to the current project):
+
+**Start / switch task** (also closes the previous active task):
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/src/tasks.js add "<task name>"
+```
+After starting, suggest packing the minimal context for it:
+`/cco-pack "<task name>"`.
+
+**List tasks** (newest first, with per-task tokens + $):
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/src/tasks.js list
+```
+
+**Complete the active task**:
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/src/tasks.js done
+```
+
+## Flow to recommend
+
+1. `/cco-task add "implement X"` — start the task
+2. `/cco-pack "implement X"` — load only the files that task needs
+3. work…
+4. `/cco` — see budget, savings, and this task's cost
+5. `/cco-task done` — freeze the task's token/$ total
+
+Only one task is active per project at a time; starting a new one finalizes the
+previous task's cost automatically.

--- a/skills/cco/SKILL.md
+++ b/skills/cco/SKILL.md
@@ -1,26 +1,46 @@
 ---
 name: cco
-description: Show context usage heatmap for current session
+description: Context Control Center — one screen for budget, $ spent, tokens saved, waste, last prompt grade, the active task, and ready-to-run optimization actions
 license: MIT
 allowed-tools: [Bash, Read]
 ---
 
-# Context Heatmap
+# Context Control Center
 
-Show the user a visual heatmap of their context usage in the current session.
+The all-in-one view of the current session. Show the user the live board, then
+the per-file heatmap if they want detail.
 
-Run the following command to get the current session's tracking data (uses the most recent session automatically):
+## 1. Show the board
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/src/dashboard.js board
+```
+
+This renders, in one screen:
+- **Budget** — % of the effective context window used + $ spent this session
+- **Saved** — tokens the Read Cache blocked → the effectiveness multiplier (e.g. "1.4x")
+- **Waste** — cold context (read but never edited) you can drop to free budget
+- **Prompt** — grade of the last prompt (from Prompt Coach)
+- **Task** — the active task and its token/$ cost (per-task attribution)
+- **Actions** — concrete next steps: what to drop → `/compact`, what to `/cco-pack`
+
+Present the board as-is. Then, based on what it shows:
+1. If an **action** line suggests dropping cold files, offer to run `/compact`.
+2. If **no task is active**, suggest `/cco-task add "<what they're working on>"` so
+   the board can attribute tokens per task.
+3. If the **prompt grade** is low (C/D/F), suggest `/cco-coach`.
+
+## 2. (Optional) per-file heatmap
+
+If the user wants the file-by-file breakdown:
 
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/src/tracker.js heatmap
 ```
 
-If no data is available yet (empty session), tell the user:
-"No data in this session yet. Just keep working — the optimizer tracks your reads, edits, and searches automatically!"
+Highlight files read but never used (waste), files that were edited (high-value),
+and the total token usage / waste percentage.
 
-Present the heatmap output to the user and highlight:
-1. Files marked with a warning icon that were read but never used — suggest avoiding them next time
-2. Files marked with an edit icon that were actually edited — these are high-value context
-3. The total estimated token usage and waste percentage
-
-If waste is over 30%, suggest specific ways to reduce it based on the files shown.
+If there is no data yet, tell the user:
+"No data in this session yet — keep working. Reads, edits, prompts and cache
+savings are tracked automatically; run /cco again to see the board fill in."

--- a/src/budget.js
+++ b/src/budget.js
@@ -5,7 +5,7 @@
  *
  * Tracks token accumulation during a session (input + estimated output) and
  * warns when approaching a configurable budget limit. Model-aware: uses the
- * effective context window for the configured model (e.g. 1M for opus-4.7-1m).
+ * effective context window for the configured model (e.g. 1M for opus-4.8).
  *
  * v3.0:
  *   - Tracks output tokens too (Edit/Write content size).
@@ -19,7 +19,7 @@ import {
   BUDGET_STATE_DIR,
   formatTokens, loadConfig, getModelCost, getEffectiveBudget,
   displayPath, loadJSON, saveJSON, ensureDataDirs, loadBudgetConfig,
-  estimateTokensFromString
+  estimateTokensFromString, isMainModule
 } from './utils.js';
 
 ensureDataDirs();
@@ -233,7 +233,8 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(() => process.exit(0));
+// Run the hook only when executed directly — importing for tests must not read stdin.
+if (isMainModule(import.meta.url)) main().catch(() => process.exit(0));
 
 // Exposed for tests
 export { estimateToolTokens, buildCompactRecommendation, computeCost };

--- a/src/context-shield.js
+++ b/src/context-shield.js
@@ -11,7 +11,7 @@
 import { basename, extname } from 'path';
 import {
   PATTERNS_FILE, SESSIONS_DIR,
-  estimateTokens, formatTokens, loadJSON, ensureDataDirs
+  estimateTokens, formatTokens, loadJSON, ensureDataDirs, isMainModule
 } from './utils.js';
 
 ensureDataDirs();
@@ -123,4 +123,4 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(() => process.exit(0));
+if (isMainModule(import.meta.url)) main().catch(() => process.exit(0));

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * Context Control Center — the one-screen flagship of v4.0.
+ *
+ * Aggregates everything the optimizer already tracks into a single view:
+ *   • Budget    — % of the effective context window used, $ spent this session
+ *   • Saved     — tokens the Read Cache blocked → "effectiveness multiplier"
+ *   • Waste     — cold context (read, never edited) you can drop to free budget
+ *   • Prompt    — grade of your last prompt (from Prompt Coach)
+ *   • Tasks     — per-task token/$ attribution (organize work by task)
+ *   • Actions   — ready-to-run next steps (drop these / pack that / compact)
+ *
+ * Two render modes:
+ *   node dashboard.js            → the live Control Center board
+ *   node dashboard.js summary    → the session-end "CCO saved you $X" report
+ *
+ * Pure aggregation: it only READS existing data files, never blocks or mutates.
+ */
+
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import {
+  SESSIONS_DIR, BUDGET_STATE_DIR, READ_CACHE_DIR, PROMPTS_DIR,
+  loadJSON, loadConfig, getEffectiveBudget, getModelCost, formatTokens, displayPath,
+  getLatestSessionId, isMainModule,
+} from './utils.js';
+import { loadTasks, getActiveTask, taskSpend, tasksForProject } from './tasks.js';
+
+// ── Data gathering ──────────────────────────────────────────────────────────
+
+function lastPromptGrade(sessionId) {
+  try {
+    const file = join(PROMPTS_DIR, `${sessionId}.jsonl`);
+    if (!existsSync(file)) return null;
+    const lines = readFileSync(file, 'utf-8').trim().split('\n').filter(Boolean);
+    if (!lines.length) return null;
+    const last = JSON.parse(lines[lines.length - 1]);
+    return { grade: last.grade, score: last.score, suggestions: last.suggestions || [] };
+  } catch { return null; }
+}
+
+export function gather(sessionId) {
+  const config = loadConfig();
+  const model = config.model || 'opus-4.8';
+  const cost = getModelCost(model);
+  const effectiveBudget = getEffectiveBudget(config);
+
+  const session = sessionId ? loadJSON(join(SESSIONS_DIR, `${sessionId}.json`)) : null;
+  const budget = sessionId ? loadJSON(join(BUDGET_STATE_DIR, `${sessionId}.json`)) : null;
+  const cache = sessionId ? loadJSON(join(READ_CACHE_DIR, `${sessionId}.json`)) : null;
+
+  const used = (budget && budget.totalTokensEstimated) || 0;
+  const inTok = (budget && budget.inputTokensEstimated) || 0;
+  const outTok = (budget && budget.outputTokensEstimated) || 0;
+  const dollars = (inTok / 1e6) * cost.input + (outTok / 1e6) * cost.output;
+
+  const saved = (cache && cache.totalTokensSaved) || 0;
+  const blocked = (cache && cache.blockedReads) || 0;
+  const multiplier = used > 0 ? (used + saved) / used : 1;
+
+  // Cold / droppable context: files read but never edited (mirrors the budget
+  // hook's compact recommendation). These are the safe-to-drop candidates.
+  const cold = [];
+  const useful = [];
+  if (session && session.files) {
+    for (const [path, f] of Object.entries(session.files)) {
+      const tokens = (f.estTokens || 0) * Math.max(1, f.reads || 1);
+      if (f.edits > 0 || f.wasEdited) useful.push({ path, tokens: f.estTokens || 0, edits: f.edits || 0 });
+      else if ((f.reads || 0) >= 1) cold.push({ path, tokens, reads: f.reads || 0 });
+    }
+  }
+  cold.sort((a, b) => b.tokens - a.tokens);
+  useful.sort((a, b) => b.edits - a.edits);
+  const reclaimable = cold.reduce((s, c) => s + c.tokens, 0);
+  const wastePct = used > 0 ? Math.min(100, Math.round((reclaimable / used) * 100)) : 0;
+
+  const prompt = sessionId ? lastPromptGrade(sessionId) : null;
+
+  const project = (session && session.projectRoot) || process.cwd();
+  const tasksState = loadTasks();
+  const active = getActiveTask(tasksState, { project });
+  const recentTasks = tasksForProject(tasksState, project, 5);
+
+  return {
+    model, cost, effectiveBudget,
+    used, inTok, outTok, dollars,
+    saved, blocked, multiplier,
+    cold, useful, reclaimable, wastePct,
+    prompt, project, active, recentTasks,
+    hasData: !!(session || budget || cache),
+  };
+}
+
+// ── Rendering helpers ─────────────────────────────────────────────────────────
+
+function bar(pct, width = 12) {
+  const filled = Math.max(0, Math.min(width, Math.round((pct / 100) * width)));
+  return '▓'.repeat(filled) + '░'.repeat(width - filled);
+}
+
+function fmtModelWindow(d) {
+  const w = d.effectiveBudget >= 1e6 ? `${(d.effectiveBudget / 1e6).toFixed(1)}M`
+    : `${Math.round(d.effectiveBudget / 1000)}K`;
+  return `${d.model} · ${w}`;
+}
+
+// ── Board ───────────────────────────────────────────────────────────────────
+
+export function renderBoard(d) {
+  if (!d.hasData) {
+    return [
+      '  CONTEXT CONTROL CENTER',
+      '  ───────────────────────────────────────────────',
+      '  No session data yet. Keep working — reads, edits,',
+      '  prompts and cache savings are tracked automatically.',
+      '  Then run /cco again to see your live board.',
+    ].join('\n');
+  }
+
+  const L = [];
+  const pct = d.effectiveBudget > 0 ? Math.round((d.used / d.effectiveBudget) * 100) : 0;
+  L.push(`  CONTEXT CONTROL CENTER          ${fmtModelWindow(d)}`);
+  L.push('  ────────────────────────────────────────────────────────────');
+  L.push(`  Budget   ${bar(pct)}  ${formatTokens(d.used)} / ${formatTokens(d.effectiveBudget)}  (${pct}%)  $${d.dollars.toFixed(3)}`);
+
+  if (d.saved > 0) {
+    L.push(`  Saved    +${formatTokens(d.saved)} tokens by cache  →  ${d.multiplier.toFixed(2)}x effective` +
+      (d.blocked ? `  (${d.blocked} reads blocked)` : ''));
+  } else {
+    L.push('  Saved    (cache warming up — savings appear after repeat reads)');
+  }
+
+  L.push(`  Waste    ${bar(d.wastePct)}  ${d.wastePct}%  (${d.cold.length} cold file${d.cold.length === 1 ? '' : 's'})`);
+
+  if (d.prompt) {
+    const hint = d.prompt.suggestions && d.prompt.suggestions.length
+      ? `  (${d.prompt.suggestions[0]})` : '';
+    L.push(`  Prompt   last grade: ${d.prompt.grade}${hint}`);
+  }
+
+  // ── Tasks ──
+  L.push('  ────────────────────────────────────────────────────────────');
+  if (d.active) {
+    const spent = taskSpend(d.active, d.used);
+    L.push(`  ▶ Task   #${d.active.id} ${d.active.name}  ·  ~${formatTokens(spent)} · $${((spent / 1e6) * d.cost.input).toFixed(3)}`);
+  } else {
+    L.push('  ▶ Task   none active  →  /cco-task add "<what you are doing>"');
+  }
+  if (d.recentTasks.length > 1) {
+    const done = d.recentTasks.filter(t => t.status === 'done').slice(0, 2);
+    for (const t of done) {
+      const spent = taskSpend(t, t.tokensAtEnd || t.tokensAtStart);
+      L.push(`  ✓ #${t.id} ${t.name}  ·  ~${formatTokens(spent)}`);
+    }
+  }
+
+  // ── Actions ──
+  L.push('  ────────────────────────────────────────────────────────────');
+  const actions = buildActions(d);
+  if (actions.length) {
+    for (const a of actions) L.push(`  ${a}`);
+  } else {
+    L.push('  ✅ Context is lean — nothing to optimize right now.');
+  }
+
+  return L.join('\n');
+}
+
+function buildActions(d) {
+  const out = [];
+  if (d.reclaimable > 3000 && d.cold.length) {
+    const top = d.cold.slice(0, 3).map(c => displayPath(c.path, 28)).join(', ');
+    out.push(`⚡ Free ~${formatTokens(d.reclaimable)}:  drop ${top}  → /compact`);
+  }
+  if (!d.active) {
+    out.push('📦 Start a task:  /cco-task add "<task>"  then  /cco-pack "<task>"');
+  } else {
+    out.push(`📦 Pack minimal context:  /cco-pack "${d.active.name}"`);
+  }
+  if (d.prompt && d.prompt.grade && 'CDF'.includes(d.prompt.grade)) {
+    out.push('✍️  Last prompt was vague — /cco-coach can sharpen the next one');
+  }
+  return out;
+}
+
+// ── Session-end summary (Auto-Optimizer report) ───────────────────────────────
+
+export function renderSummary(d) {
+  if (!d.hasData || (d.saved === 0 && d.used === 0)) return '';
+  const L = [];
+  L.push('  ── CCO session summary ───────────────────────────────────────');
+  if (d.saved > 0) {
+    const savedDollars = (d.saved / 1e6) * d.cost.input;
+    L.push(`  CCO saved you ${formatTokens(d.saved)} tokens this session (~$${savedDollars.toFixed(2)}).`);
+    L.push(`  Your ${formatTokens(d.effectiveBudget)} budget worked like ${formatTokens(Math.round(d.used + d.saved))} (${d.multiplier.toFixed(2)}x).`);
+  } else {
+    L.push(`  Tracked ${formatTokens(d.used)} tokens this session ($${d.dollars.toFixed(2)}).`);
+  }
+  if (d.reclaimable > 3000) {
+    L.push(`  Tip: ~${formatTokens(d.reclaimable)} of cold context is still loaded — /compact before next task.`);
+  }
+  return L.join('\n');
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function main() {
+  const mode = process.argv[2] || 'board';
+  const sessionId = process.argv[3] || getLatestSessionId();
+  const d = gather(sessionId);
+  if (mode === 'summary') {
+    const s = renderSummary(d);
+    if (s) console.log(s);
+  } else {
+    console.log(renderBoard(d));
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  try { main(); } catch (e) { console.error(`[cco] dashboard error: ${e.message}`); process.exit(0); }
+}

--- a/src/git-context.js
+++ b/src/git-context.js
@@ -10,7 +10,7 @@
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { join, dirname, extname, basename } from 'path';
-import { PATTERNS_FILE, loadJSON } from './utils.js';
+import { PATTERNS_FILE, loadJSON, isMainModule } from './utils.js';
 
 function run(cmd, cwd) {
   try {
@@ -214,4 +214,4 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-main().catch(() => process.exit(0));
+if (isMainModule(import.meta.url)) main().catch(() => process.exit(0));

--- a/src/prompt-coach.js
+++ b/src/prompt-coach.js
@@ -30,7 +30,7 @@ import { readFileSync, existsSync, writeFileSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import {
   PROMPTS_DIR, ensureDataDirs, loadJSON, saveJSON,
-  estimateTokensFromString, isQuietMode
+  estimateTokensFromString, isQuietMode, isMainModule
 } from './utils.js';
 
 ensureDataDirs();
@@ -377,4 +377,4 @@ async function main() {
   await hookMode();
 }
 
-main().catch(() => process.exit(0));
+if (isMainModule(import.meta.url)) main().catch(() => process.exit(0));

--- a/src/read-cache.js
+++ b/src/read-cache.js
@@ -30,7 +30,7 @@ import { statSync } from 'fs';
 import {
   READ_CACHE_DIR,
   estimateTokens, formatTokens, loadJSON, saveJSON, ensureDataDirs,
-  loadConfig, getEffectiveBudget
+  loadConfig, getEffectiveBudget, isMainModule
 } from './utils.js';
 import { isContextIgnored } from './contextignore.js';
 import { parseFileStructure, formatDigest } from './file-digest.js';
@@ -39,7 +39,8 @@ ensureDataDirs();
 
 // ── Adaptive staleness configuration ──────────────────────────────────────────
 // Thresholds scale with the user's effective context budget so the cache
-// behaves correctly on both 200K (Sonnet) and 1M (Opus 4.7 1M) windows.
+// behaves correctly on both 200K (Haiku 4.5) and 1M (Opus 4.8 / Opus 4.7 /
+// Sonnet 4.6 — all 1M at standard price) windows.
 //
 // Default ratios (calibrated against 200K window where the previous fixed
 // values were 20K/8/10min) — the same fractions on 1M give ~100K/40/10min
@@ -334,4 +335,4 @@ async function main() {
   console.log(JSON.stringify({ decision: 'block', reason }));
 }
 
-main().catch(() => process.exit(0));
+if (isMainModule(import.meta.url)) main().catch(() => process.exit(0));

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+/**
+ * Task register — the "organize work by task" layer of the Context Control Center.
+ *
+ * A task is a named unit of work. While a task is active, the tokens your
+ * session spends are attributed to it, so the dashboard can show cost *per task*
+ * (not just per session). Combined with Smart Pack (/cco-pack), each task gets
+ * the minimal context it needs and you can see which task is burning budget.
+ *
+ * Storage: one JSON file (TASKS_FILE), a flat list of tasks scoped by project +
+ * session. At most one task is "active" per (project, session) at a time.
+ *
+ * The core logic is pure (no I/O) so it is unit-testable; loadTasks/saveTasks
+ * wrap it with disk access.
+ */
+
+import {
+  TASKS_FILE, loadJSON, saveJSON, ensureDataDirs, isMainModule,
+  formatTokens, getModelCost, loadConfig, getLatestSessionId, getSessionTokenTotal
+} from './utils.js';
+
+const STATE_VERSION = 1;
+
+export function emptyState() {
+  return { version: STATE_VERSION, tasks: [], nextId: 1 };
+}
+
+// ── Pure logic ────────────────────────────────────────────────────────────────
+
+/** Find the active task for a (project, session), or null. */
+export function getActiveTask(state, { project = null, sessionId = null } = {}) {
+  for (let i = state.tasks.length - 1; i >= 0; i--) {
+    const t = state.tasks[i];
+    if (t.status !== 'active') continue;
+    if (project != null && t.project !== project) continue;
+    if (sessionId != null && t.sessionId !== sessionId) continue;
+    return t;
+  }
+  return null;
+}
+
+/** Tokens attributed to a task: delta of session tokens over the task window. */
+export function taskSpend(task, tokensNow) {
+  const end = task.status === 'done' ? (task.tokensAtEnd ?? task.tokensAtStart) : tokensNow;
+  return Math.max(0, (end || 0) - (task.tokensAtStart || 0));
+}
+
+/**
+ * Start a new task. Any currently-active task in the same (project, session) is
+ * completed first (one active task at a time). Returns { state, task }.
+ */
+export function addTask(state, { name, project = null, sessionId = null, tokensNow = 0, files = [], stamp = null }) {
+  const next = { ...state, tasks: [...state.tasks] };
+  // Close the current active task in this scope.
+  const active = getActiveTask(next, { project, sessionId });
+  if (active) {
+    const idx = next.tasks.indexOf(active);
+    next.tasks[idx] = { ...active, status: 'done', tokensAtEnd: tokensNow, completedAt: stamp };
+  }
+  const id = next.nextId || 1;
+  const task = {
+    id,
+    name: String(name || 'untitled').trim().slice(0, 120),
+    project,
+    sessionId,
+    status: 'active',
+    createdAt: stamp,
+    completedAt: null,
+    tokensAtStart: tokensNow,
+    tokensAtEnd: null,
+    packedFiles: Array.isArray(files) ? files.slice(0, 200) : [],
+    note: '',
+  };
+  next.tasks.push(task);
+  next.nextId = id + 1;
+  return { state: next, task };
+}
+
+/** Complete the active task in a scope. Returns { state, task|null }. */
+export function completeActiveTask(state, { project = null, sessionId = null, tokensNow = 0, note = '', stamp = null } = {}) {
+  const active = getActiveTask(state, { project, sessionId });
+  if (!active) return { state, task: null };
+  const next = { ...state, tasks: [...state.tasks] };
+  const idx = next.tasks.indexOf(active);
+  const done = { ...active, status: 'done', tokensAtEnd: tokensNow, completedAt: stamp, note: note || active.note };
+  next.tasks[idx] = done;
+  return { state: next, task: done };
+}
+
+/** Tasks for a project (newest first), optional limit. */
+export function tasksForProject(state, project, limit = 20) {
+  return state.tasks
+    .filter(t => project == null || t.project === project)
+    .slice()
+    .reverse()
+    .slice(0, limit);
+}
+
+// ── I/O ───────────────────────────────────────────────────────────────────────
+
+export function loadTasks() {
+  const data = loadJSON(TASKS_FILE);
+  if (!data || !Array.isArray(data.tasks)) return emptyState();
+  if (typeof data.nextId !== 'number') {
+    data.nextId = data.tasks.reduce((m, t) => Math.max(m, (t.id || 0) + 1), 1);
+  }
+  return data;
+}
+
+export function saveTasks(state) {
+  ensureDataDirs();
+  saveJSON(TASKS_FILE, state);
+}
+
+// ── CLI (used by the cco-task skill) ───────────────────────────────────────────
+
+function fmtCost(tokens, model) {
+  // Rough blended estimate: treat attributed tokens as input for a conservative $.
+  const c = getModelCost(model);
+  return ((tokens / 1_000_000) * c.input).toFixed(3);
+}
+
+function printTasks(state, project, model) {
+  const list = tasksForProject(state, project, 12);
+  if (!list.length) {
+    console.log('No tasks yet. Start one:  /cco-task add "<what you are working on>"');
+    return;
+  }
+  console.log('  Tasks (newest first)');
+  console.log('  ─────────────────────────────────────────────────────────────');
+  for (const t of list) {
+    const spent = taskSpend(t, t.tokensAtEnd || t.tokensAtStart);
+    const mark = t.status === 'active' ? '▶' : '✓';
+    const cost = fmtCost(spent, model);
+    const files = t.packedFiles?.length ? ` · ${t.packedFiles.length} files` : '';
+    console.log(`  ${mark} #${t.id} ${t.name}`);
+    console.log(`      ~${formatTokens(spent)} tokens · $${cost}${files}`);
+  }
+}
+
+function main() {
+  const action = process.argv[2] || 'list';
+  const rest = process.argv.slice(3).join(' ').trim();
+  const project = process.env.CCO_PROJECT || process.cwd();
+  const sessionId = getLatestSessionId();
+  const model = (loadConfig().model) || 'opus-4.8';
+  const tokensNow = getSessionTokenTotal(sessionId);
+  const stamp = new Date().toISOString();
+  let state = loadTasks();
+
+  if (action === 'add') {
+    if (!rest) { console.error('Usage: cco-task add "<name>"'); process.exit(1); }
+    const r = addTask(state, { name: rest, project, sessionId, tokensNow, stamp });
+    saveTasks(r.state);
+    console.log(`▶ Started task #${r.task.id}: ${r.task.name}`);
+    console.log('  Pack the minimal context for it:  /cco-pack "' + r.task.name + '"');
+    return;
+  }
+  if (action === 'done') {
+    const r = completeActiveTask(state, { project, tokensNow, note: rest, stamp });
+    if (!r.task) { console.log('No active task to complete.'); return; }
+    saveTasks(r.state);
+    const spent = taskSpend(r.task, tokensNow);
+    console.log(`✓ Completed task #${r.task.id}: ${r.task.name}  (~${formatTokens(spent)} tokens, $${fmtCost(spent, model)})`);
+    return;
+  }
+  // default: list
+  printTasks(state, project, model);
+}
+
+if (isMainModule(import.meta.url)) {
+  try { main(); } catch (e) { console.error(`[cco-task] ${e.message}`); process.exit(0); }
+}

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -15,7 +15,7 @@ import {
   DATA_DIR, SESSIONS_DIR, PATTERNS_FILE, GLOBAL_STATS_FILE, TEMPLATES_DIR, SUMMARIES_DIR,
   estimateTokens, formatTokens, displayPath, computeUsefulness, computeConfidence,
   getDonationMessage, loadJSON, saveJSON, ensureDataDirs,
-  shouldIgnoreForTracking, getFileLines, getProjectRoot
+  shouldIgnoreForTracking, getFileLines, getProjectRoot, isMainModule
 } from './utils.js';
 
 ensureDataDirs();
@@ -1005,7 +1005,9 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(err => {
-  console.error(`[cco] Error: ${err.message}`);
-  process.exit(0);
-});
+if (isMainModule(import.meta.url)) {
+  main().catch(err => {
+    console.error(`[cco] Error: ${err.message}`);
+    process.exit(0);
+  });
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,9 +5,25 @@
  * usefulness scoring, JSON I/O, file classification, and config management.
  */
 
-import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync, statSync, realpathSync, readdirSync } from 'fs';
 import { join, basename, extname } from 'path';
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+
+// ── Main-module guard ────────────────────────────────────────────────────────
+// True only when the given module is the process entry point (i.e. run as
+// `node src/foo.js`), false when it is imported by another module (e.g. tests).
+// Hook modules use this to guard their stdin-reading main() — importing them
+// for unit testing must NOT start the hook, or the test process hangs forever
+// waiting on stdin (this caused the v3.6.0 CI runs to time out at 6h).
+export function isMainModule(metaUrl) {
+  try {
+    if (!process.argv[1]) return false;
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(metaUrl));
+  } catch {
+    return false;
+  }
+}
 
 // ── Data directories ─────────────────────────────────────────────────────────
 
@@ -23,19 +39,27 @@ export const TEMPLATES_DIR = join(DATA_DIR, 'templates');
 export const EXPORTS_DIR = join(DATA_DIR, 'exports');
 export const SUMMARIES_DIR = join(DATA_DIR, 'summaries');
 export const PROMPTS_DIR = join(DATA_DIR, 'prompts');
+export const TASKS_FILE = join(DATA_DIR, 'tasks.json');
 
-// ── Model costs ($/M tokens — input/output) — anthropic.com/pricing ──────────
-// Updated for current model lineup. Output costs included for accurate ROI.
-
+// ── Model costs ($/M tokens — input/output) — platform.claude.com/docs pricing ─
+// Current lineup (Opus 4.8 era). Output costs included for accurate ROI.
+//   • Opus 4.7 / 4.8 — $5/$25, full 1M context window at standard price
+//     (there is NO long-context premium; the old "1M tier surcharge" is gone).
+//   • Sonnet 4.6 — $3/$15, 1M context window.
+//   • Haiku 4.5 — $1/$5, 200K context window.
 export const MODEL_COSTS = {
-  'haiku':         { input: 1,    output: 5,    contextWindow: 200_000  },
-  'haiku-4.5':     { input: 1,    output: 5,    contextWindow: 200_000  },
-  'sonnet':        { input: 3,    output: 15,   contextWindow: 200_000  },
-  'sonnet-4.6':    { input: 3,    output: 15,   contextWindow: 200_000  },
-  'opus':          { input: 15,   output: 75,   contextWindow: 200_000  },
-  'opus-4.7':      { input: 15,   output: 75,   contextWindow: 200_000  },
-  'opus-4.7-1m':   { input: 22.5, output: 112.5, contextWindow: 1_000_000 }, // 1M-context tier
-  'opus-extended': { input: 15,   output: 75,   contextWindow: 200_000  },
+  'haiku':         { input: 1,  output: 5,  contextWindow:   200_000 },
+  'haiku-4.5':     { input: 1,  output: 5,  contextWindow:   200_000 },
+  'sonnet':        { input: 3,  output: 15, contextWindow: 1_000_000 },
+  'sonnet-4.6':    { input: 3,  output: 15, contextWindow: 1_000_000 },
+  'opus':          { input: 5,  output: 25, contextWindow: 1_000_000 },
+  'opus-4.7':      { input: 5,  output: 25, contextWindow: 1_000_000 },
+  'opus-4.8':      { input: 5,  output: 25, contextWindow: 1_000_000 },
+  // Back-compat aliases — these used to carry a fictional 1M surcharge; the 1M
+  // window is now standard, so they map to the standard Opus price.
+  'opus-4.7-1m':   { input: 5,  output: 25, contextWindow: 1_000_000 },
+  'opus-4.8-1m':   { input: 5,  output: 25, contextWindow: 1_000_000 },
+  'opus-extended': { input: 5,  output: 25, contextWindow: 1_000_000 },
 };
 
 // Backwards-compatible numeric accessor (input price only — used by old callsites).
@@ -154,10 +178,10 @@ export function saveJSON(file, data) {
 // ── Config ───────────────────────────────────────────────────────────────────
 
 const DEFAULT_CONFIG = {
-  budgetTokens: 200000,        // 200K — sane default for Sonnet/Opus 4.7
+  budgetTokens: 200000,        // 200K — sane working default even on 1M-window models
   warnAt: [50, 70, 85, 95],
   autoCompactAt: 90,
-  model: 'opus-4.7'
+  model: 'opus-4.8'
 };
 
 export function loadConfig() {
@@ -180,6 +204,30 @@ export function getEffectiveBudget(config) {
   const cfg = config || loadConfig();
   const window = getModelContextWindow(cfg.model);
   return Math.min(cfg.budgetTokens || DEFAULT_CONFIG.budgetTokens, window);
+}
+
+// ── Session resolution (shared by skills that have no event stdin) ───────────
+// Slash-command skills run as plain processes without the hook's session_id,
+// so they resolve "the current session" as the most-recently-updated session
+// file — the same convention tracker/report/digest already use.
+
+export function getLatestSessionId() {
+  try {
+    const files = readdirSync(SESSIONS_DIR)
+      .filter(f => f.endsWith('.json'))
+      .map(f => ({ name: f, mtime: statSync(join(SESSIONS_DIR, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+    return files.length ? files[0].name.replace(/\.json$/, '') : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Total estimated tokens spent in a session (from budget state), or 0. */
+export function getSessionTokenTotal(sessionId) {
+  if (!sessionId) return 0;
+  const state = loadJSON(join(BUDGET_STATE_DIR, `${sessionId}.json`));
+  return (state && state.totalTokensEstimated) || 0;
 }
 
 // ── Budget config (auto-compact settings) ────────────────────────────────────

--- a/tests/test.js
+++ b/tests/test.js
@@ -9,9 +9,13 @@ import {
   loadBudgetConfig, saveBudgetConfig, clearBudgetConfigCache,
   BUDGET_CONFIG_FILE, loadJSON,
   MODEL_COSTS, getModelCost, getModelContextWindow,
-  getEffectiveBudget, categorizeFile, shouldSkipFile, shouldIgnoreForTracking
+  getEffectiveBudget, categorizeFile, shouldSkipFile, shouldIgnoreForTracking,
+  isMainModule
 } from '../src/utils.js';
 import { analyzePrompt, buildImprovedPrompt } from '../src/prompt-coach.js';
+import {
+  emptyState, addTask, completeActiveTask, getActiveTask, taskSpend, tasksForProject
+} from '../src/tasks.js';
 import { estimateToolTokens, computeCost } from '../src/budget.js';
 import {
   isContextIgnored, _globToRegex, _parseIgnoreFile, clearContextIgnoreCache
@@ -949,50 +953,146 @@ describe('staleness detection', () => {
 // ── Model cost tests (Opus 4.7-aware) ───────────────────────────────────────
 
 describe('model costs', () => {
-  it('opus-4.7 has correct prices', () => {
-    const c = getModelCost('opus-4.7');
-    assert.equal(c.input, 15);
-    assert.equal(c.output, 75);
-    assert.equal(c.contextWindow, 200_000);
-  });
-
-  it('opus-4.7-1m has 1M context and surcharge', () => {
-    const c = getModelCost('opus-4.7-1m');
+  it('opus-4.8 has correct prices and 1M window', () => {
+    const c = getModelCost('opus-4.8');
+    assert.equal(c.input, 5);
+    assert.equal(c.output, 25);
     assert.equal(c.contextWindow, 1_000_000);
-    assert.ok(c.input > 15, 'input price should be higher for 1M tier');
-    assert.ok(c.output > 75, 'output price should be higher for 1M tier');
   });
 
-  it('haiku-4.5 has correct prices', () => {
+  it('opus-4.7 matches opus-4.8 pricing and 1M window', () => {
+    const c = getModelCost('opus-4.7');
+    assert.equal(c.input, 5);
+    assert.equal(c.output, 25);
+    assert.equal(c.contextWindow, 1_000_000);
+  });
+
+  it('1m aliases carry no surcharge (standard Opus price)', () => {
+    const c = getModelCost('opus-4.8-1m');
+    assert.equal(c.contextWindow, 1_000_000);
+    assert.equal(c.input, 5, '1M window is standard-priced — no premium');
+    assert.equal(c.output, 25);
+  });
+
+  it('sonnet-4.6 has correct prices and 1M window', () => {
+    const c = getModelCost('sonnet-4.6');
+    assert.equal(c.input, 3);
+    assert.equal(c.output, 15);
+    assert.equal(c.contextWindow, 1_000_000);
+  });
+
+  it('haiku-4.5 has correct prices and 200K window', () => {
     const c = getModelCost('haiku-4.5');
     assert.equal(c.input, 1);
     assert.equal(c.output, 5);
+    assert.equal(c.contextWindow, 200_000);
   });
 
   it('falls back to opus when model unknown', () => {
     const c = getModelCost('unknown-model-xyz');
-    assert.equal(c.input, 15);
+    assert.equal(c.input, 5);
   });
 
   it('getModelContextWindow returns correct window', () => {
-    assert.equal(getModelContextWindow('opus-4.7-1m'), 1_000_000);
+    assert.equal(getModelContextWindow('opus-4.8'), 1_000_000);
     assert.equal(getModelContextWindow('haiku-4.5'), 200_000);
   });
 });
 
+// ── Import safety (regression: v3.6.0 hooks hung CI by reading stdin on import) ─
+
+// ── Task register (per-task context attribution) ────────────────────────────
+
+describe('tasks', () => {
+  const P = '/proj/a';
+
+  it('emptyState has no tasks', () => {
+    const s = emptyState();
+    assert.equal(s.tasks.length, 0);
+    assert.equal(getActiveTask(s, { project: P }), null);
+  });
+
+  it('addTask creates one active task with a token baseline', () => {
+    const { state, task } = addTask(emptyState(), { name: 'fix bug', project: P, tokensNow: 5000 });
+    assert.equal(task.status, 'active');
+    assert.equal(task.tokensAtStart, 5000);
+    assert.equal(getActiveTask(state, { project: P }).id, task.id);
+  });
+
+  it('starting a new task completes the previous active one (one active at a time)', () => {
+    let { state } = addTask(emptyState(), { name: 'first', project: P, tokensNow: 1000 });
+    const r = addTask(state, { name: 'second', project: P, tokensNow: 4000 });
+    state = r.state;
+    const active = getActiveTask(state, { project: P });
+    assert.equal(active.name, 'second');
+    // first task is closed and its end snapshot is the second task's start
+    const first = state.tasks.find(t => t.name === 'first');
+    assert.equal(first.status, 'done');
+    assert.equal(first.tokensAtEnd, 4000);
+  });
+
+  it('taskSpend is the token delta over the task window, floored at 0', () => {
+    const { task } = addTask(emptyState(), { name: 't', project: P, tokensNow: 2000 });
+    assert.equal(taskSpend(task, 9000), 7000);
+    assert.equal(taskSpend(task, 1000), 0); // never negative
+  });
+
+  it('completeActiveTask freezes the spend', () => {
+    const { state } = addTask(emptyState(), { name: 't', project: P, tokensNow: 2000 });
+    const r = completeActiveTask(state, { project: P, tokensNow: 12000 });
+    assert.equal(r.task.status, 'done');
+    assert.equal(taskSpend(r.task, 999999), 10000); // frozen at completion delta
+    assert.equal(getActiveTask(r.state, { project: P }), null);
+  });
+
+  it('tasks are scoped by project', () => {
+    let { state } = addTask(emptyState(), { name: 'a-task', project: '/proj/a', tokensNow: 0 });
+    state = addTask(state, { name: 'b-task', project: '/proj/b', tokensNow: 0 }).state;
+    assert.equal(getActiveTask(state, { project: '/proj/a' }).name, 'a-task');
+    assert.equal(getActiveTask(state, { project: '/proj/b' }).name, 'b-task');
+    assert.equal(tasksForProject(state, '/proj/a').length, 1);
+  });
+
+  it('tasksForProject returns newest first', () => {
+    let s = emptyState();
+    s = addTask(s, { name: 'one', project: P, tokensNow: 0 }).state;
+    s = addTask(s, { name: 'two', project: P, tokensNow: 0 }).state;
+    const list = tasksForProject(s, P);
+    assert.equal(list[0].name, 'two');
+  });
+});
+
+describe('import safety (isMainModule guard)', () => {
+  it('isMainModule is true for the entry module (this test file, run directly)', () => {
+    // node --test tests/test.js makes this file the process entry point.
+    assert.equal(isMainModule(import.meta.url), true);
+  });
+
+  it('isMainModule is false for any module that is not the entry point', () => {
+    // An imported hook module (budget.js, prompt-coach.js, …) has a url that is
+    // NOT process.argv[1], so its guarded main() never fires on import. If it
+    // did, main() would block on process.stdin — exactly what hung v3.6.0 CI 6h.
+    assert.equal(isMainModule('file:///some/other/module.js'), false);
+  });
+
+  // The real regression guard is that this test file finishes and the process
+  // exits at all: it imports budget.js and prompt-coach.js, whose guarded
+  // main() must NOT read stdin on import.
+});
+
 describe('getEffectiveBudget', () => {
-  it('caps budget at model context window', () => {
-    const budget = getEffectiveBudget({ budgetTokens: 2_000_000, model: 'opus-4.7' });
+  it('caps budget at model context window (haiku = 200K)', () => {
+    const budget = getEffectiveBudget({ budgetTokens: 2_000_000, model: 'haiku-4.5' });
     assert.equal(budget, 200_000);
   });
 
   it('honours user budget below model window', () => {
-    const budget = getEffectiveBudget({ budgetTokens: 50_000, model: 'opus-4.7' });
+    const budget = getEffectiveBudget({ budgetTokens: 50_000, model: 'opus-4.8' });
     assert.equal(budget, 50_000);
   });
 
-  it('allows up to 1M for opus-4.7-1m', () => {
-    const budget = getEffectiveBudget({ budgetTokens: 1_000_000, model: 'opus-4.7-1m' });
+  it('allows up to 1M for opus-4.8 (1M is standard)', () => {
+    const budget = getEffectiveBudget({ budgetTokens: 1_000_000, model: 'opus-4.8' });
     assert.equal(budget, 1_000_000);
   });
 });
@@ -1153,16 +1253,16 @@ describe('budget', () => {
   describe('computeCost', () => {
     it('charges input + output at model rates', () => {
       const state = { inputTokensEstimated: 1_000_000, outputTokensEstimated: 1_000_000 };
-      const cost = computeCost(state, 'opus-4.7');
-      // 1M * $15 input + 1M * $75 output = $90
-      assert.equal(cost, 90);
+      const cost = computeCost(state, 'opus-4.8');
+      // 1M * $5 input + 1M * $25 output = $30
+      assert.equal(cost, 30);
     });
 
-    it('opus-4.7-1m costs more than opus-4.7', () => {
-      const state = { inputTokensEstimated: 1_000_000, outputTokensEstimated: 0 };
-      const c1 = computeCost(state, 'opus-4.7');
-      const c2 = computeCost(state, 'opus-4.7-1m');
-      assert.ok(c2 > c1);
+    it('opus costs more than sonnet for the same usage', () => {
+      const state = { inputTokensEstimated: 1_000_000, outputTokensEstimated: 1_000_000 };
+      const opus = computeCost(state, 'opus-4.8');
+      const sonnet = computeCost(state, 'sonnet-4.6');
+      assert.ok(opus > sonnet);
     });
   });
 });


### PR DESCRIPTION
## Why
The **v3.6.0** release was broken: CI jobs `test (18/20/22)` and `publish` ran to the **6-hour GitHub timeout and were cancelled** (the red ×3/6). Root cause: `budget.js` and `prompt-coach.js` (new in v3.6.0) called `main()` **unconditionally on import**, and `main()` reads `process.stdin` — so when the test suite imported them, the process never exited. All assertions passed; the process just hung.

## What's in this PR

### 1. CI fix (the actual bug)
- All six hook modules now guard `main()` with `isMainModule(import.meta.url)` so importing them for tests never starts the stdin-reading hook.
- Added a regression test; `node --test` now **exits cleanly — 128/128 pass**.

### 2. Opus 4.8 + corrected pricing (real inaccuracy fixed)
- Opus 4.7/4.8 are **$5/$25 per MTok at 1M context, no premium**. Default model → `opus-4.8`.
- Removed the fictional `opus-4.7-1m` **$22.50/$112.50** "1M tier" (kept as a back-compat alias → standard $5/$25 1M).
- Sonnet 4.6 is **1M** ($3/$15); Haiku 4.5 stays 200K ($1/$5).
- Updated `MODEL_COSTS`, tests, README, skills, landing page; version **4.0.0**.

### 3. Flagship — Context Control Center
- **`/cco`** one-screen board: budget %, $ spent, tokens saved by cache (effectiveness multiplier), waste/cold files, last prompt grade, active task cost, ready-to-run actions. (`src/dashboard.js`)
- **`/cco-task add|list|done`** — organize work by task with per-task token/$ attribution. (`src/tasks.js`)
- Session-end Auto-Optimizer report wired into the `SessionEnd` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)