### PR TITLE
fix(report): repair cco-report crash (syntax error) and $NaN cost figures

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -10,7 +10,7 @@ import { existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import {
   SESSIONS_DIR, GLOBAL_STATS_FILE,
-  formatTokens, loadJSON, loadConfig, MODEL_COSTS
+  formatTokens, loadJSON, loadConfig, MODEL_INPUT_COST
 } from './utils.js';
 
 function generateFullReport() {
@@ -43,10 +43,10 @@ function generateFullReport() {
   report += `  Overall waste ratio:        ${overallWaste}%\n`;
 
   const primaryModel = config.model || 'opus';
-  const primaryCost = (stats.estimatedTokensSaved / 1000000) * (MODEL_COSTS[primaryModel] || 15);
+  const primaryCost = (stats.estimatedTokensSaved / 1000000) * (MODEL_INPUT_COST[primaryModel] || MODEL_INPUT_COST.opus);
   if (stats.estimatedTokensSaved > 5000) {
     report += `  Est. $ saveable (${primaryModel}):   $${primaryCost.toFixed(2)}\n`;
-    for (const [model, rate] of Object.entries(MODEL_COSTS)) {
+    for (const [model, rate] of Object.entries(MODEL_INPUT_COST)) {
       if (model !== primaryModel) {
         const cost = (stats.estimatedTokensSaved / 1000000) * rate;
         report += `  Est. $ saveable (${model}):   $${cost.toFixed(2)}\n`;
@@ -119,7 +119,7 @@ function generateFullReport() {
     report += '      - Avoiding reading large config files fully\n';
     report += '      - Using /compact when switching tasks\n';
   } else {
-    report += '  You're a context pro — tokens well spent!\n';
+    report += '  You\'re a context pro — tokens well spent!\n';
   }
 
   if (stats.avgTokensPerSession > 80000) {


### PR DESCRIPTION
## Summary

Two independent, reproducible bugs in `src/report.js` (both present on `v4.1.0` / `main`) that together prevent `cco-report full` from working. Each fix is a one-liner; no behavior change beyond making the report run and print correct numbers.

## Bug 1 — `cco-report full` crashes for everyone (syntax error)

Line 122 builds a string with an apostrophe inside single quotes:

```js
report += '  You're a context pro — tokens well spent!\n';
```

JavaScript parses the whole module before executing, so this `SyntaxError` aborts the entire command — `cco-report full` prints **nothing**, regardless of the user's actual waste level:

```
SyntaxError: Unexpected identifier 're'
    at compileSourceTextModule (node:internal/modules/esm/utils:354:16)
    ...
```

**Fix:** escape the apostrophe (`You\'re`).

## Bug 2 — every "$ saveable" line prints `$NaN`

Lines 46 & 49 treat `MODEL_COSTS[model]` as a scalar rate:

```js
const primaryCost = (stats.estimatedTokensSaved / 1000000) * (MODEL_COSTS[primaryModel] || 15);
...
for (const [model, rate] of Object.entries(MODEL_COSTS)) {
```

But in `utils.js`, `MODEL_COSTS` values are objects, not numbers:

```js
'opus-4.8': { input: 5, output: 25, contextWindow: 1_000_000 },
```

So `tokens * { input, output, ... }` → `NaN`, and the `|| 15` fallback never fires because the key *does* exist. Result:

```
Est. $ saveable (opus-4.8):   $NaN
Est. $ saveable (haiku):      $NaN
... (every model)
```

`utils.js` already exports the right accessor for this exact use:

```js
export const MODEL_INPUT_COST = Object.fromEntries(
  Object.entries(MODEL_COSTS).map(([k, v]) => [k, v.input])
);
```

**Fix:** import and use `MODEL_INPUT_COST` (input price per model), and replace the stale `|| 15` default with the opus input price for self-consistency with `getModelCost`'s opus fallback.

## Verification

```
$ node --check src/report.js
OK: parses cleanly

$ node src/report.js full   # before: SyntaxError, no output
  Est. $ saveable (opus-4.8):   $0.86
  Est. $ saveable (sonnet-4.6): $0.52
  Est. $ saveable (haiku-4.5):  $0.17
  ...
```

Both bugs were found while running `/cco-report` as a normal user; the report was completely non-functional until both were fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
