### PR TITLE
fix(roi): repair $NaN / [object Object] in cco-roi cost table

### DIFF
--- a/src/roi.js
+++ b/src/roi.js
@@ -10,7 +10,7 @@
 import { readdirSync, existsSync } from 'fs';
 import {
   SESSIONS_DIR, DATA_DIR,
-  formatTokens, loadJSON, MODEL_COSTS, ensureDataDirs
+  formatTokens, loadJSON, MODEL_INPUT_COST, ensureDataDirs
 } from './utils.js';
 
 ensureDataDirs();
@@ -55,7 +55,7 @@ function buildROITable(avgWastePercent, avgTokensPerSession, sessionsPerDay) {
   const rows = [];
 
   for (const model of models) {
-    const cost = MODEL_COSTS[model];
+    const cost = MODEL_INPUT_COST[model];
     const savedPerSession = avgTokensPerSession * (avgWastePercent / 100);
     const costPerSession = (avgTokensPerSession / 1_000_000) * cost;
     const savingsPerSession = (savedPerSession / 1_000_000) * cost;


### PR DESCRIPTION
## Summary

`/cco-roi` is fully broken in its money output — same bug class as #29, just in `src/roi.js` instead of `src/report.js`.

## Bug

`roi.js` treats `MODEL_COSTS[model]` as a scalar price per million tokens:

```js
const cost = MODEL_COSTS[model];          // line 58
const costPerSession = (avgTokens / 1e6) * cost;
pricePerM: `$${cost}`,
```

But in `utils.js` the values are objects:

```js
'opus': { input: 5, output: 25, contextWindow: 1_000_000 },
```

So `tokens * { input, output, ... }` → `NaN`, and `` `$${cost}` `` → `$[object Object]`. The entire "Monthly Savings by Model" table and the "Team ROI" figures were garbage.

**Before:**
```
Model     $/M tok            Per session   Per day    Per month   Per year
Haiku     $[object Object]   $NaN          $NaN       $NaN        $NaN
...
Team ROI: Monthly: $NaN
```

## Fix

Use the `MODEL_INPUT_COST` accessor `utils.js` already exports for exactly this (input price per model), matching the #29 fix.

**After:**
```
Model     $/M tok   Per session   Per day    Per month   Per year
Haiku     $1        $0.01         $0.05      $1          $17
Sonnet    $3        $0.03         $0.14      $4          $52
Opus      $5        $0.05         $0.24      $7          $86
Team ROI: Monthly: $70   Yearly: $840
```

## Verification

- `node --check src/roi.js` → OK
- `node src/roi.js` → real numbers, no `NaN` / `[object Object]`
- `npm test` → 139/139 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)