### PR TITLE
release: v4.3.0 — cache economics, /cco-overhead, auto-contextignore, calibration, delegation advisor, ru/en coach

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
   "plugins": [
     {
       "name": "claude-context-optimizer",
-      "description": "Opus 4.8-aware context optimization: real token counts from transcripts, race-free hooks, honest NET savings, big-file map-then-load, Context Control Center, per-task tracking, prompt coach",
-      "version": "4.2.0",
+      "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach",
+      "version": "4.3.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.2.0",
-  "description": "Opus 4.8-aware context optimization: real token counts from transcripts, race-free hooks, honest NET savings, big-file map-then-load, Context Control Center, per-task tracking, prompt coach",
+  "version": "4.3.0",
+  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach",
   "author": {
     "name": "Egor Fedorov"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 4.3.0 — 2026-07-04
+
+### Prompt Coach stops grading conversation (trust fix)
+- New classifier (`classifyPrompt`): prompts are `chat` / `question` / `task`.
+  Conversational replies ("спасибо, всё ок") are no longer graded F with
+  "name the file you want changed" advice injected into context — the coach
+  now coaches only actual work requests. Questions are graded for history but
+  never coached.
+- **Russian language support**: strong/vague verbs, unbounded phrases, success
+  hints, and interrogatives. Also fixes a latent bug: JS `\b` is ASCII-only,
+  so Cyrillic verb matching silently never worked.
+- Follow-up leniency: short mid-session prompts lean on loaded context and are
+  no longer coached unless truly unbounded.
+
+### Cache economics — the real billing lever (`/cco`)
+- Session cost is now priced at **real prompt-cache rates** (reads 10%, writes
+  125% of input) from exact transcript usage, instead of pricing every token
+  at the full input rate (which overstated cost up to ~10×).
+- New **Cache line** on the `/cco` board: hit rate, $ saved vs uncached, and
+  **cache breaks** — moments the warm cache went cold (>5 min pause, mid-session
+  CLAUDE.md edit, model switch) and the whole context was re-written at 1.25×.
+  The session summary calls out breaks with their extra cost.
+
+### NEW `/cco-overhead` — session baseline audit
+- Measures the fixed context every session starts with (system prompt, tools,
+  MCP, agents, CLAUDE.md, memory) from ground-truth transcript usage: latest,
+  average across recent sessions, % of budget, and $ per session.
+- Itemizes locally measurable sources (project/global CLAUDE.md, memory index,
+  agent definitions) and flags the unattributed remainder with concrete
+  recommendations. Baseline trims repay in EVERY session.
+
+### `/cco-shield suggest|apply` — close the waste loop
+- `suggest` turns files wasted in 3+ sessions into ready `.contextignore`
+  patterns (with per-session savings); `apply` appends them, deduped against
+  existing rules. Observation → permanent rule.
+
+### Self-calibrating estimates
+- At session end, the real/estimated token ratio is EMA'd into config
+  (clamped 0.5–2×) and the budget hook multiplies its input estimates by it.
+  The chars-per-token heuristic now learns each codebase's actual drift.
+
+### Delegation advisor
+- 12+ consecutive Read/Grep/Glob calls with no edits and 20K+ tokens pinned in
+  main context now triggers a one-per-session suggestion to delegate broad
+  exploration to a subagent (whose context is discarded — only the conclusion
+  returns). Resets on any edit or Agent call.
+
+### Tests
+- 150 → 170: prompt classification (ru/en), cache-break detection, cache-aware
+  cost math, baseline parsing, ignore suggestions, calibration EMA, streak
+  advisor.
+
 ## 4.2.0 — 2026-07-04
 
 ### Real token counts (ground truth)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,32 @@ At $5/M input tokens (Opus 4.8), a developer spending $100/month is lighting **$
 
 ---
 
+## What's new in v4.3 — cache economics & a politer coach
+
+- **Real cache-aware pricing.** Session cost is now computed at true prompt-cache
+  rates (cache reads bill at 10%, writes at 125% of input) from exact transcript
+  usage. The `/cco` board gains a **Cache line**: hit rate, $ saved vs uncached,
+  and **cache breaks** — moments a >5-min pause or a mid-session CLAUDE.md edit
+  went and re-wrote your whole context at the 1.25× rate, with the extra $ shown.
+- **NEW `/cco-overhead`.** Every session starts with a fixed payload — system
+  prompt, tool schemas, MCP servers, agents, CLAUDE.md — paid before you type a
+  word. This audit measures it from ground truth (first-turn API usage), itemizes
+  what's measurable locally, and tells you what to trim. Baseline cuts repay in
+  *every* session.
+- **Prompt Coach stops grading conversation.** "спасибо, всё ок" is no longer an
+  F-grade prompt with injected advice to "name the file you want changed". The
+  coach classifies chat / question / task, coaches only tasks, goes easier on
+  short follow-ups — and now understands **Russian**.
+- **`/cco-shield apply`.** Files wasted in 3+ sessions become `.contextignore`
+  rules with one command — observation closes into a permanent rule.
+- **Self-calibrating estimates.** Real transcript totals teach the token
+  estimator each codebase's drift (EMA, clamped) — estimates get honest on
+  their own.
+- **Delegation advisor.** A long read-only exploration streak in the main
+  context triggers a one-time hint to fan it out to a subagent instead.
+
+---
+
 ## What's new in v4.2 — ground truth
 
 - **Real token counts.** The budget hook now reads **exact API usage** from the
@@ -436,7 +462,8 @@ When installed as a plugin, commands are namespaced: `/claude-context-optimizer:
 | `/cco-templates [list\|create\|apply\|delete]` | Context templates — reusable file sets for task types |
 | `/cco-export [md\|html]` | Export reports — Markdown or static HTML dashboard |
 | `/cco-clean` | Cleanup — remove old tracking data |
-| `/cco-shield` | ContextShield status — waste protection stats |
+| `/cco-shield [suggest\|apply]` | ContextShield status; **NEW** — turn waste history into `.contextignore` rules |
+| `/cco-overhead` | **NEW** — audit the fixed baseline every session starts with (system prompt, MCP, agents, CLAUDE.md) |
 | `/cco-claudemd` | CLAUDE.md analyzer — find and fix token bloat |
 | `/cco-anatomy` | Project anatomy — compact codebase map with file sizes and token estimates |
 | `/cco-replay [N]` | Session replay — recent session summaries for quick context recovery |
@@ -625,9 +652,10 @@ claude-context-optimizer/
 │   ├── file-digest.js       # Structural file map (map-then-load for big files)
 │   ├── simulate-savings.js  # Savings simulator over recorded sessions
 │   ├── export.js            # Chart.js HTML dashboard exporter
-│   ├── prompt-coach.js      # NEW — UserPromptSubmit hook + CLI: prompt quality scoring
-│   ├── smart-pack.js        # NEW — Optimal file pack builder (git + history + keywords)
-│   └── doctor.js            # NEW — Health check CLI
+│   ├── prompt-coach.js      # UserPromptSubmit hook + CLI: prompt classification & quality scoring
+│   ├── smart-pack.js        # Optimal file pack builder (git + history + keywords)
+│   ├── overhead.js          # NEW — session baseline overhead audit (/cco-overhead)
+│   └── doctor.js            # Health check CLI
 ├── skills/
 │   ├── cco/SKILL.md               # /cco — Context Control Center (one-screen board)
 │   ├── cco-task/SKILL.md          # NEW — /cco-task — per-task tokens/$ tracking
@@ -645,7 +673,8 @@ claude-context-optimizer/
 │   ├── cco-anatomy/SKILL.md       # /cco-anatomy — project anatomy
 │   ├── cco-coach/SKILL.md         # NEW — /cco-coach prompt quality grader
 │   ├── cco-pack/SKILL.md          # NEW — /cco-pack smart context pack
-│   ├── cco-doctor/SKILL.md        # NEW — /cco-doctor health check
+│   ├── cco-doctor/SKILL.md        # /cco-doctor health check
+│   ├── cco-overhead/SKILL.md      # NEW — /cco-overhead session baseline audit
 │   └── smart-loader/SKILL.md      # Auto-suggestion skill (model-invoked)
 ├── agents/
 │   └── context-analyzer.md  # Deep analysis agent

--- a/docs/index.html
+++ b/docs/index.html
@@ -836,7 +836,7 @@
   <div class="container">
     <div class="badge">
       <div class="badge-dot"></div>
-      v4.2.0 &middot; Opus 4.8 ready &middot; 1M context aware &middot; Benchmarked
+      v4.3.0 &middot; Opus 4.8 ready &middot; 1M context aware &middot; Benchmarked
     </div>
     <div class="hero-stat">63%</div>
     <h1>fewer tokens. <span class="highlight">Sharper prompts.</span><br>Tuned for Opus 4.8.</h1>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.2.0",
-  "description": "Opus 4.8-aware context optimization: real token counts from transcripts, race-free hooks, honest NET savings, big-file map-then-load, Context Control Center, per-task tracking, prompt coach",
+  "version": "4.3.0",
+  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach",
   "type": "module",
   "main": "src/tracker.js",
   "bin": {

--- a/skills/cco-overhead/SKILL.md
+++ b/skills/cco-overhead/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cco-overhead
+description: Audit the fixed context overhead every session starts with — system prompt, MCP tools, agents, CLAUDE.md, memory — measured from real transcript usage
+license: MIT
+allowed-tools: [Bash, Read]
+---
+
+# Session Baseline Overhead Audit
+
+Measure how many tokens every session of this project pays BEFORE any work
+happens — and where to cut.
+
+Run:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/src/overhead.js
+```
+
+The report shows:
+
+1. **Baseline** — exact context size at the first assistant response (from the
+   session transcript's API usage counts), latest and averaged over recent
+   sessions, as a % of the working budget.
+2. **Cost per session** — what that baseline costs to write into the prompt
+   cache each session.
+3. **Itemization** — the locally measurable parts (project + global CLAUDE.md,
+   memory index, agent definitions) and the unattributed remainder (system
+   prompt, tool schemas, MCP servers).
+4. **Recommendations** — what to trim and how (e.g. `/cco-claudemd`, disabling
+   unused MCP servers, pruning agent descriptions).
+
+Present the output to the user as-is (it is already formatted). If the report
+says no transcripts were found, explain that the audit needs at least one
+completed exchange in a session for this project.
+
+Key framing for the user: baseline overhead is paid in EVERY session, so a
+one-time trim repays itself continuously — it is usually the highest-leverage
+optimization available.

--- a/skills/cco-shield/SKILL.md
+++ b/skills/cco-shield/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cco-shield
-description: Show ContextShield status and waste protection stats
+description: Show ContextShield status and waste protection stats; suggest or apply .contextignore rules from historical waste
 license: MIT
 allowed-tools: [Bash, Read]
 ---
@@ -8,6 +8,22 @@ allowed-tools: [Bash, Read]
 # ContextShield Status
 
 Show the user the current ContextShield protection status and historical waste prevention stats.
+
+## Subcommands
+
+If the user asked for suggestions (`/cco-shield suggest`) or to apply them
+(`/cco-shield apply`), run instead:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/src/context-shield.js suggest   # preview .contextignore candidates
+node ${CLAUDE_PLUGIN_ROOT}/src/context-shield.js apply     # append them to ./.contextignore
+```
+
+`suggest` lists files wasted in 3+ sessions as ready-to-use `.contextignore`
+patterns with per-session token savings. `apply` appends them (deduped against
+existing rules) so those reads are blocked permanently. Show the output as-is.
+
+## Status report (default)
 
 Run the following command to get pattern data:
 

--- a/src/budget.js
+++ b/src/budget.js
@@ -20,7 +20,7 @@ import {
   BUDGET_STATE_DIR,
   formatTokens, loadConfig, getModelCost, getEffectiveBudget,
   displayPath, loadJSON, saveJSON, ensureDataDirs, loadBudgetConfig,
-  estimateTokens, isMainModule
+  estimateTokens, isMainModule, getCalibrationFactor
 } from './utils.js';
 import { emitNotice } from './notices.js';
 import { readRealUsage } from './transcript-usage.js';
@@ -144,7 +144,12 @@ async function main() {
   const budgetConfig = loadBudgetConfig();
   const state = loadBudgetState(sessionId);
 
-  const { input: inAdded, output: outAdded } = estimateToolTokens(toolName, toolInput);
+  const est = estimateToolTokens(toolName, toolInput);
+  // Self-calibration: sessions with transcript ground truth teach the local
+  // real/estimated drift (see utils.updateCalibrationFromSession). Input-side
+  // only — output estimates already come from exact string lengths.
+  const inAdded = Math.round(est.input * getCalibrationFactor());
+  const outAdded = est.output;
   state.inputTokensEstimated += inAdded;
   state.outputTokensEstimated += outAdded;
   state.totalTokensEstimated = state.inputTokensEstimated + state.outputTokensEstimated;
@@ -173,6 +178,9 @@ async function main() {
   if (real && real.contextTokens > 0) {
     state.realContextTokens = real.contextTokens;
   }
+  // Remember where the transcript lives so the dashboard (a plain CLI with no
+  // hook event) can compute full-session cache economics on demand.
+  if (event.transcript_path) state.transcriptPath = event.transcript_path;
 
   const effectiveBudget = getEffectiveBudget(config);
   const contextNow = state.realContextTokens || state.totalTokensEstimated;

--- a/src/context-shield.js
+++ b/src/context-shield.js
@@ -8,7 +8,8 @@
  * Suggests alternatives: Grep instead of Read, offset/limit for large files.
  */
 
-import { basename, extname } from 'path';
+import { basename, extname, join, relative } from 'path';
+import { existsSync, readFileSync, appendFileSync } from 'fs';
 import {
   PATTERNS_FILE, SESSIONS_DIR,
   estimateTokens, formatTokens, loadJSON, ensureDataDirs, isMainModule
@@ -35,7 +36,74 @@ function findProjectForPath(patterns, filePath) {
   return null;
 }
 
+// ── .contextignore suggestions (close the loop: observation → rule) ─────────
+// The shield WARNS about files wasted in 3+ sessions; this turns those
+// observations into permanent .contextignore rules so the waste stops for good.
+
+/**
+ * Build suggestion list from historical waste patterns. Pure — for tests.
+ * Returns [{ pattern, sessions, tokens }] sorted by tokens wasted, deduped
+ * against lines already present in existingIgnore (array of pattern strings).
+ */
+export function buildIgnoreSuggestions(patterns, projectRoot, existingIgnore = [], minSessions = 3) {
+  const existing = new Set(existingIgnore.map(l => l.trim()).filter(Boolean));
+  const out = [];
+  for (const [projKey, proj] of Object.entries(patterns.projects || {})) {
+    if (projKey !== '_global' && projKey !== projectRoot) continue;
+    for (const [filePath, d] of Object.entries(proj.wastedReads || {})) {
+      if ((d.sessions || 0) < minSessions) continue;
+      if (!filePath.startsWith(projectRoot + '/')) continue;
+      const pattern = relative(projectRoot, filePath);
+      if (!pattern || pattern.startsWith('..') || existing.has(pattern)) continue;
+      out.push({ pattern, sessions: d.sessions, tokens: d.totalTokensWasted || 0 });
+    }
+  }
+  return out.sort((a, b) => b.tokens - a.tokens).slice(0, 20);
+}
+
+function readIgnoreLines(cwd) {
+  const file = join(cwd, '.contextignore');
+  if (!existsSync(file)) return [];
+  try { return readFileSync(file, 'utf-8').split('\n'); } catch { return []; }
+}
+
+function suggestOrApply(mode) {
+  const cwd = process.cwd();
+  const patterns = loadPatterns();
+  const suggestions = buildIgnoreSuggestions(patterns, cwd, readIgnoreLines(cwd));
+
+  if (!suggestions.length) {
+    console.log('\n  No .contextignore candidates yet — nothing was wasted in 3+ sessions');
+    console.log('  (or the waste files are already ignored). Keep working; patterns accrue.\n');
+    return;
+  }
+
+  const total = suggestions.reduce((s, x) => s + x.tokens, 0);
+  console.log(`\n  .CONTEXTIGNORE ${mode === 'apply' ? 'APPLIED' : 'SUGGESTIONS'} — ${suggestions.length} file(s), ~${formatTokens(total)} tokens/session saveable`);
+  console.log('  ' + '─'.repeat(60));
+  for (const s of suggestions) {
+    console.log(`  ${s.pattern.padEnd(44)} wasted in ${s.sessions} sessions (~${formatTokens(s.tokens)})`);
+  }
+
+  if (mode === 'apply') {
+    const file = join(cwd, '.contextignore');
+    const block = `\n# Added by /cco-shield apply — files unused in 3+ sessions (${new Date().toISOString().slice(0, 10)})\n` +
+      suggestions.map(s => s.pattern).join('\n') + '\n';
+    appendFileSync(file, block);
+    console.log(`\n  ✓ Appended ${suggestions.length} pattern(s) to ${file}`);
+    console.log('  Reads of these files are now blocked (Grep still works). Edit the file to undo.\n');
+  } else {
+    console.log('\n  Run `/cco-shield apply` to append these to .contextignore.\n');
+  }
+}
+
 async function main() {
+  const action = process.argv[2];
+  if (action === 'suggest' || action === 'apply') {
+    suggestOrApply(action);
+    return;
+  }
+
   let input = '';
   for await (const chunk of process.stdin) {
     input += chunk;

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -23,10 +23,12 @@ import { existsSync, readFileSync } from 'fs';
 import {
   SESSIONS_DIR, BUDGET_STATE_DIR, READ_CACHE_DIR, PROMPTS_DIR,
   loadJSON, loadConfig, getEffectiveBudget, getModelCost, formatTokens, displayPath,
-  getLatestSessionId, isMainModule,
+  getLatestSessionId, isMainModule, computeCacheAwareCost, CACHE_WRITE_MULT, CACHE_READ_MULT,
+  updateCalibrationFromSession,
 } from './utils.js';
 import { loadTasks, getActiveTask, taskSpend, tasksForProject } from './tasks.js';
 import { loadLedger } from './notices.js';
+import { readTranscriptEconomics } from './transcript-usage.js';
 
 // ── Data gathering ──────────────────────────────────────────────────────────
 
@@ -56,7 +58,31 @@ export function gather(sessionId) {
   const used = (budget && (budget.realContextTokens || budget.totalTokensEstimated)) || 0;
   const inTok = (budget && budget.inputTokensEstimated) || 0;
   const outTok = (budget && budget.outputTokensEstimated) || 0;
-  const dollars = (inTok / 1e6) * cost.input + (outTok / 1e6) * cost.output;
+
+  // Cache economics — exact usage totals from the full transcript, priced at
+  // real cache rates (reads 10%, writes 125% of input). This is what the
+  // session actually bills; the estimate below stays as the fallback.
+  const econ = budget && budget.transcriptPath
+    ? readTranscriptEconomics(budget.transcriptPath) : null;
+  let dollars, cacheEcon = null;
+  if (econ) {
+    const costs = computeCacheAwareCost(econ.totals, model);
+    dollars = costs.real;
+    const inputSide = econ.totals.input + econ.totals.cacheRead + econ.totals.cacheCreation;
+    const breakTokens = econ.breaks.reduce((s, b) => s + b.lostTokens, 0);
+    cacheEcon = {
+      hitPct: inputSide > 0 ? Math.round((econ.totals.cacheRead / inputSide) * 100) : 0,
+      savings: costs.cacheSavings,
+      naive: costs.naive,
+      breaks: econ.breaks.length,
+      breakTokens,
+      // A break re-writes cached tokens at 1.25× instead of re-reading at 0.1×.
+      breakCost: (breakTokens / 1e6) * cost.input * (CACHE_WRITE_MULT - CACHE_READ_MULT),
+      turns: econ.turns,
+    };
+  } else {
+    dollars = (inTok / 1e6) * cost.input + (outTok / 1e6) * cost.output;
+  }
 
   const savedGross = (cache && cache.totalTokensSaved) || 0;
   const blocked = (cache && cache.blockedReads) || 0;
@@ -92,7 +118,7 @@ export function gather(sessionId) {
 
   return {
     model, cost, effectiveBudget,
-    used, inTok, outTok, dollars,
+    used, inTok, outTok, dollars, cacheEcon,
     saved, savedGross, overhead, blocked, multiplier,
     cold, useful, reclaimable, wastePct,
     prompt, project, active, recentTasks,
@@ -140,6 +166,13 @@ export function renderBoard(d) {
     L.push(`  Saved    net ~0  (cache saved ${formatTokens(d.savedGross)}, CCO messages cost ${formatTokens(d.overhead)})`);
   } else {
     L.push('  Saved    (cache warming up — savings appear after repeat reads)');
+  }
+
+  if (d.cacheEcon) {
+    const c = d.cacheEcon;
+    let line = `  Cache    ${bar(c.hitPct)}  ${c.hitPct}% hit  ·  saved $${c.savings.toFixed(2)} vs uncached`;
+    if (c.breaks > 0) line += `  ·  ${c.breaks} break${c.breaks === 1 ? '' : 's'} (−$${c.breakCost.toFixed(2)})`;
+    L.push(line);
   }
 
   L.push(`  Waste    ${bar(d.wastePct)}  ${d.wastePct}%  (${d.cold.length} cold file${d.cold.length === 1 ? '' : 's'})`);
@@ -209,6 +242,14 @@ export function renderSummary(d) {
   } else {
     L.push(`  Tracked ${formatTokens(d.used)} tokens this session ($${d.dollars.toFixed(2)}).`);
   }
+  if (d.cacheEcon) {
+    const c = d.cacheEcon;
+    L.push(`  Prompt cache: ${c.hitPct}% hit rate saved $${c.savings.toFixed(2)} vs uncached pricing.`);
+    if (c.breaks > 0) {
+      L.push(`  ⚠ Cache broke ${c.breaks}x (${formatTokens(c.breakTokens)} re-written, ~$${c.breakCost.toFixed(2)} extra).` +
+        ` Common causes: >5 min pauses, editing CLAUDE.md mid-session, switching models.`);
+    }
+  }
   if (d.reclaimable > 3000) {
     L.push(`  Tip: ~${formatTokens(d.reclaimable)} of cold context is still loaded — /compact before next task.`);
   }
@@ -224,6 +265,11 @@ function main() {
   if (mode === 'summary') {
     const s = renderSummary(d);
     if (s) console.log(s);
+    // Session is over — let ground truth teach the estimator its local drift.
+    const budget = sessionId ? loadJSON(join(BUDGET_STATE_DIR, `${sessionId}.json`)) : null;
+    if (budget && budget.realContextTokens && budget.totalTokensEstimated) {
+      updateCalibrationFromSession(budget.realContextTokens, budget.totalTokensEstimated);
+    }
   } else {
     console.log(renderBoard(d));
   }

--- a/src/overhead.js
+++ b/src/overhead.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+/**
+ * Session Baseline Overhead audit — /cco-overhead
+ *
+ * The biggest invisible token spend isn't redundant reads — it's the FIXED
+ * overhead every session starts with: system prompt, tool schemas, MCP
+ * servers, agent lists, CLAUDE.md, memory. You pay it before typing a word,
+ * and again in every session.
+ *
+ * This tool measures it from ground truth: the first assistant message of a
+ * session transcript carries exact API usage — that's the context loaded
+ * before any work happened. It then itemizes the parts that are measurable
+ * locally (CLAUDE.md files, memory index, agent definitions) and labels the
+ * rest "system prompt & tools (unattributed)".
+ *
+ * Usage:
+ *   node src/overhead.js [transcript.jsonl]   # specific transcript
+ *   node src/overhead.js                      # last 10 sessions of this project
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import {
+  formatTokens, estimateTokensFromString, loadConfig, getModelCost,
+  getEffectiveBudget, CACHE_WRITE_MULT, isMainModule, getDonationMessage,
+} from './utils.js';
+
+// ── Pure parsing (exported for tests) ───────────────────────────────────────
+
+/**
+ * Baseline = context present at the FIRST assistant response: system prompt,
+ * tools, CLAUDE.md, memory, and the user's opening prompt. Exact API counts.
+ */
+export function parseBaselineFromLines(lines) {
+  for (const line of lines) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    const u = obj && obj.message && obj.message.usage;
+    if (u && typeof u.input_tokens === 'number') {
+      return (u.input_tokens || 0) +
+             (u.cache_read_input_tokens || 0) +
+             (u.cache_creation_input_tokens || 0);
+    }
+  }
+  return null;
+}
+
+// ── Transcript discovery ─────────────────────────────────────────────────────
+
+/** Claude Code stores transcripts under ~/.claude/projects/<munged-cwd>/. */
+export function projectTranscriptDir(cwd) {
+  return join(homedir(), '.claude', 'projects', cwd.replace(/[/.]/g, '-'));
+}
+
+function recentTranscripts(cwd, limit = 10) {
+  const dir = projectTranscriptDir(cwd);
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir)
+      .filter(f => f.endsWith('.jsonl'))
+      .map(f => ({ path: join(dir, f), mtime: statSync(join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime)
+      .slice(0, limit)
+      .map(t => t.path);
+  } catch {
+    return [];
+  }
+}
+
+function baselineOf(transcriptPath) {
+  try {
+    // Baseline lives at the head of the file — 512KB is plenty.
+    const buf = readFileSync(transcriptPath, 'utf-8').slice(0, 512 * 1024);
+    return parseBaselineFromLines(buf.split('\n').filter(Boolean));
+  } catch {
+    return null;
+  }
+}
+
+// ── Locally measurable overhead sources ──────────────────────────────────────
+
+function tokensOfFile(path, ext = '.md') {
+  try {
+    if (!existsSync(path)) return 0;
+    return estimateTokensFromString(readFileSync(path, 'utf-8'), ext);
+  } catch { return 0; }
+}
+
+function tokensOfAgentDir(dir) {
+  // Agent frontmatter (name + description) is what lands in the system prompt.
+  let tokens = 0, count = 0;
+  try {
+    if (!existsSync(dir)) return { tokens, count };
+    for (const f of readdirSync(dir).filter(f => f.endsWith('.md'))) {
+      const content = readFileSync(join(dir, f), 'utf-8');
+      const fm = content.match(/^---\n([\s\S]*?)\n---/);
+      tokens += estimateTokensFromString(fm ? fm[1] : content.slice(0, 2000));
+      count++;
+    }
+  } catch { /* best-effort */ }
+  return { tokens, count };
+}
+
+export function measureLocalSources(cwd) {
+  const home = homedir();
+  const items = [];
+
+  const add = (label, tokens, hint) => {
+    if (tokens > 0) items.push({ label, tokens, hint });
+  };
+
+  add('Project CLAUDE.md', tokensOfFile(join(cwd, 'CLAUDE.md')),
+    'trim with /cco-claudemd');
+  add('Global ~/.claude/CLAUDE.md', tokensOfFile(join(home, '.claude', 'CLAUDE.md')),
+    'loaded in EVERY project — keep it minimal');
+  add('Memory index (MEMORY.md)',
+    tokensOfFile(join(projectTranscriptDir(cwd), 'memory', 'MEMORY.md')),
+    'one line per memory is the rule');
+
+  const projAgents = tokensOfAgentDir(join(cwd, '.claude', 'agents'));
+  add(`Project agents (${projAgents.count})`, projAgents.tokens,
+    'each agent description is in every system prompt');
+  const userAgents = tokensOfAgentDir(join(home, '.claude', 'agents'));
+  add(`User agents (${userAgents.count})`, userAgents.tokens,
+    'disable agents you never invoke');
+
+  return items;
+}
+
+// ── Report ───────────────────────────────────────────────────────────────────
+
+export function buildReport(cwd, transcriptArg) {
+  const config = loadConfig();
+  const model = config.model || 'opus-4.8';
+  const cost = getModelCost(model);
+  const budget = getEffectiveBudget(config);
+
+  const transcripts = transcriptArg ? [transcriptArg] : recentTranscripts(cwd);
+  const baselines = transcripts
+    .map(p => ({ path: p, baseline: baselineOf(p) }))
+    .filter(b => b.baseline && b.baseline > 0);
+
+  const L = [];
+  L.push('');
+  L.push('  SESSION BASELINE OVERHEAD');
+  L.push('  ' + '─'.repeat(60));
+
+  if (!baselines.length) {
+    L.push('  No session transcripts found for this project yet.');
+    L.push(`  Looked in: ${projectTranscriptDir(cwd)}`);
+    L.push('  Start a session, do one exchange, then run /cco-overhead again.');
+    return L.join('\n');
+  }
+
+  const latest = baselines[0].baseline;
+  const avg = Math.round(baselines.reduce((s, b) => s + b.baseline, 0) / baselines.length);
+  const pctOfBudget = Math.round((avg / budget) * 100);
+  // Every session writes the baseline into cache once at the 1.25× rate.
+  const perSession = (avg / 1e6) * cost.input * CACHE_WRITE_MULT;
+
+  L.push(`  Latest session started at   ${formatTokens(latest)} tokens before any work`);
+  L.push(`  Average over ${String(baselines.length).padStart(2)} session(s)   ${formatTokens(avg)} tokens  (${pctOfBudget}% of your ${formatTokens(budget)} budget)`);
+  L.push(`  Cost per session            ~$${perSession.toFixed(3)} written to cache (${model})`);
+  L.push('');
+
+  const items = measureLocalSources(cwd).sort((a, b) => b.tokens - a.tokens);
+  const itemized = items.reduce((s, i) => s + i.tokens, 0);
+  const unattributed = Math.max(0, avg - itemized);
+
+  L.push('  Where it goes (locally measurable):');
+  for (const i of items) {
+    L.push(`    ${i.label.padEnd(30)} ~${formatTokens(i.tokens).padStart(7)}   ${i.hint}`);
+  }
+  L.push(`    ${'System prompt, tools & MCP'.padEnd(30)} ~${formatTokens(unattributed).padStart(7)}   check /context; disable unused MCP servers`);
+  L.push('');
+
+  // ── Recommendations ──
+  const recs = [];
+  const claudeMd = items.find(i => i.label === 'Project CLAUDE.md');
+  if (claudeMd && claudeMd.tokens > 3000) {
+    recs.push(`Project CLAUDE.md is ~${formatTokens(claudeMd.tokens)} — run /cco-claudemd to trim it.`);
+  }
+  if (unattributed > 40_000) {
+    recs.push(`~${formatTokens(unattributed)} is system prompt/tools/MCP — run /context in a fresh session ` +
+      `to see the breakdown, and disable MCP servers you don't use here.`);
+  }
+  if (pctOfBudget > 30) {
+    recs.push(`Baseline eats ${pctOfBudget}% of your working budget before you type — every trim here repays in EVERY session.`);
+  }
+  if (recs.length) {
+    L.push('  Recommendations:');
+    for (const r of recs) L.push(`    • ${r}`);
+  } else {
+    L.push('  ✅ Baseline is lean for this model and budget.');
+  }
+  L.push(getDonationMessage());
+  return L.join('\n');
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  const arg = process.argv[2];
+  console.log(buildReport(process.cwd(), arg));
+}
+
+if (isMainModule(import.meta.url)) {
+  try { main(); } catch (e) { console.error(`[cco] overhead error: ${e.message}`); process.exit(0); }
+}

--- a/src/prompt-coach.js
+++ b/src/prompt-coach.js
@@ -39,12 +39,20 @@ ensureDataDirs();
 
 const VAGUE_VERBS = [
   'improve', 'optimize', 'optimise', 'clean up', 'refactor', 'better',
-  'make it nice', 'fix issues', 'fix problems', 'tidy', 'polish'
+  'make it nice', 'fix issues', 'fix problems', 'tidy', 'polish',
+  // Russian
+  'улучши', 'улучшить', 'оптимизируй', 'оптимизировать', 'почисти',
+  'сделай лучше', 'сделай красиво', 'наведи порядок', 'отрефактори',
 ];
 
 const STRONG_VERBS = [
   'add', 'remove', 'rename', 'replace', 'extract', 'inline',
-  'implement', 'create', 'delete', 'fix', 'debug', 'test', 'document'
+  'implement', 'create', 'delete', 'fix', 'debug', 'test', 'document',
+  // Russian imperatives
+  'добавь', 'удали', 'убери', 'исправь', 'почини', 'поправь', 'сделай',
+  'создай', 'замени', 'переименуй', 'вынеси', 'реализуй', 'напиши',
+  'допиши', 'перепиши', 'настрой', 'обнови', 'проверь', 'протестируй',
+  'запусти', 'разбей', 'найди', 'задеплой', 'релизни', 'закоммить',
 ];
 
 const UNBOUNDED_PHRASES = [
@@ -53,6 +61,8 @@ const UNBOUNDED_PHRASES = [
   /\bredesign\s+(everything|the\s+app|the\s+system)/i,
   /\bmake\s+it\s+(nice|better|good|cool|awesome|amazing|perfect)\b/i,
   /\b(improve|optimi[sz]e|fix|refactor|clean\s*up)\s+(everything|all|the\s+(codebase|whole|entire))/i,
+  /все\s+(баги|ошибки|файлы|тесты|проблемы)/i,
+  /(перепиши|переделай)\s+(вс[её]|весь|всю)/i,
 ];
 
 const SUCCESS_HINTS = [
@@ -62,7 +72,89 @@ const SUCCESS_HINTS = [
   /\backceptance criteri/i,
   /\bdone when\b/i,
   /\buntil\b/i,
+  /\bчтобы\b/i,
+  /тест(ы)?\s.*проход/i,
+  /должн[оаы]\s/i,
+  /ошибк[аи]\s+(исчез|пропа)/i,
 ];
+
+// ── Language-aware word matching ────────────────────────────────────────────
+// JS \b is ASCII-only: it never fires between a space and a Cyrillic letter,
+// so `\bдобавь\b` silently matches nothing. Cyrillic words use a plain
+// case-insensitive substring check instead (safe for these imperatives).
+
+const CYRILLIC = /[а-яё]/i;
+function hasWord(text, word) {
+  if (CYRILLIC.test(word)) return text.toLowerCase().includes(word);
+  return new RegExp(`\\b${word}\\b`, 'i').test(text);
+}
+
+// ── Conversation classifier ─────────────────────────────────────────────────
+// Not every prompt is a task. Grading "спасибо, всё отлично ))" as F and
+// injecting "name the file you want changed" spends the very tokens the
+// optimizer protects — and erodes trust. Classify first, coach only tasks.
+
+const ACK_WORDS = [
+  // English
+  'ok', 'okay', 'yes', 'no', 'thanks', 'thank', 'cool', 'nice', 'great',
+  'good', 'perfect', 'awesome', 'lgtm', 'sure', 'fine', 'hi', 'hello', 'hey',
+  'continue', 'proceed', 'go', 'stop', 'wait', 'bye',
+  // Russian
+  'да', 'нет', 'ок', 'окей', 'спасибо', 'спс', 'отлично', 'круто', 'супер',
+  'хорошо', 'понял', 'поняла', 'ясно', 'ага', 'угу', 'привет', 'давай',
+  'поехали', 'продолжай', 'дальше', 'стоп', 'подожди', 'норм', 'пока',
+];
+
+const INTERROGATIVES = [
+  // English
+  'why', 'how', 'what', 'who', 'when', 'where', 'which', 'can', 'could',
+  'should', 'is', 'are', 'does', 'do',
+  // Russian
+  'почему', 'зачем', 'откуда', 'как', 'что', 'кто', 'где', 'когда',
+  'какой', 'какая', 'какие', 'можно', 'есть',
+];
+
+/**
+ * Classify a prompt as 'chat' (conversational — don't grade),
+ * 'question' (legit question — grade leniently, never inject),
+ * or 'task' (a work request — full coaching applies).
+ */
+export function classifyPrompt(prompt) {
+  const trimmed = (prompt || '').trim();
+  if (!trimmed) return 'chat';
+
+  // Strip emoji, emoticons ("))", ":)"), and punctuation for word analysis.
+  const cleaned = trimmed
+    .replace(/[)(:;=~^]+/g, ' ')
+    .replace(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu, ' ')
+    .trim();
+  const words = cleaned.split(/\s+/).filter(Boolean);
+
+  const hasTaskVerb = STRONG_VERBS.some(v => hasWord(cleaned, v));
+  const hasFilePath = FILE_PATH_REGEX.test(cleaned);
+  FILE_PATH_REGEX.lastIndex = 0; // global regex — reset between uses
+  const hasErrorText = /error|exception|traceback|TypeError|ошибк/i.test(cleaned);
+
+  // Question shape: ends with "?" or opens with an interrogative (optionally
+  // after a filler particle like "а" / "so"). Checked before the chat rule so
+  // short questions ("how does X work?") aren't dismissed as chit-chat.
+  const first = (words[0] || '').toLowerCase().replace(/[.,!?…]+$/, '');
+  const second = (words[1] || '').toLowerCase().replace(/[.,!?…]+$/, '');
+  const isQuestionShape = /\?\s*$/.test(trimmed) ||
+    INTERROGATIVES.includes(first) ||
+    (first.length <= 2 && INTERROGATIVES.includes(second));
+
+  if (!hasTaskVerb && isQuestionShape) return 'question';
+
+  // Chat: short, no task verb, no file, no error — acknowledgments, reactions.
+  if (!hasTaskVerb && !hasFilePath && !hasErrorText) {
+    if (words.length <= 6) return 'chat';
+    const lower = words.map(w => w.toLowerCase().replace(/[.,!?…]+$/, ''));
+    if (words.length <= 10 && lower.some(w => ACK_WORDS.includes(w))) return 'chat';
+  }
+
+  return 'task';
+}
 
 const TECH_HINTS = [
   /\berror[:\s]/i,
@@ -100,7 +192,7 @@ export function analyzePrompt(prompt) {
   const hasSuccess = SUCCESS_HINTS.some(re => re.test(trimmed));
   const hasTechContext = TECH_HINTS.some(re => re.test(trimmed));
   const hasVagueVerb = VAGUE_VERBS.some(v => trimmed.toLowerCase().includes(v));
-  const hasStrongVerb = STRONG_VERBS.some(v => new RegExp(`\\b${v}\\b`, 'i').test(trimmed));
+  const hasStrongVerb = STRONG_VERBS.some(v => hasWord(trimmed, v));
   const hasUnbounded = UNBOUNDED_PHRASES.some(re => re.test(trimmed));
   const hasCodeBlock = /```/.test(trimmed);
   const hasQuestionMark = /\?/.test(trimmed);
@@ -218,11 +310,12 @@ async function readStdin() {
   return input;
 }
 
-function logPrompt(sessionId, prompt, analysis) {
+function logPrompt(sessionId, prompt, analysis, kind = 'task') {
   try {
     const file = join(PROMPTS_DIR, `${sessionId}.jsonl`);
     const entry = JSON.stringify({
       ts: new Date().toISOString(),
+      kind,
       score: analysis.score,
       grade: analysis.grade,
       wordCount: analysis.wordCount,
@@ -234,6 +327,15 @@ function logPrompt(sessionId, prompt, analysis) {
     // can't truncate earlier entries, unlike read+concat+write).
     appendFileSync(file, entry);
   } catch { /* best-effort */ }
+}
+
+/** Count previously logged prompts this session (0 = this is the opener). */
+function priorPromptCount(sessionId) {
+  try {
+    const file = join(PROMPTS_DIR, `${sessionId}.jsonl`);
+    if (!existsSync(file)) return 0;
+    return readFileSync(file, 'utf-8').split('\n').filter(Boolean).length;
+  } catch { return 0; }
 }
 
 async function hookMode() {
@@ -248,11 +350,31 @@ async function hookMode() {
   const prompt = event.prompt || '';
   const sessionId = event.session_id || 'unknown';
 
+  // Classify BEFORE grading. Conversational replies and questions are not
+  // weak task prompts — coaching them injects noise (and tokens) for nothing.
+  const kind = classifyPrompt(prompt);
+
+  if (kind === 'chat') {
+    logPrompt(sessionId, prompt, { score: null, grade: '-', wordCount: 0, signals: {}, suggestions: [] }, kind);
+    process.exit(0);
+  }
+
+  const priors = priorPromptCount(sessionId); // before logging this one
   const analysis = analyzePrompt(prompt);
-  logPrompt(sessionId, prompt, analysis);
+  logPrompt(sessionId, prompt, analysis, kind);
+
+  // Questions get graded for history but never coached — "name the file you
+  // want changed" is meaningless advice for "why did X happen?".
+  if (kind === 'question') process.exit(0);
 
   // Strong prompt or quiet mode — stay silent.
   if (analysis.score >= 80 || isQuietMode()) {
+    process.exit(0);
+  }
+
+  // Follow-up leniency: mid-conversation, short prompts lean on context that
+  // is already loaded. Only coach follow-ups that are truly unbounded.
+  if (priors > 0 && analysis.wordCount < 12 && !analysis.signals.hasUnbounded) {
     process.exit(0);
   }
 

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -261,6 +261,36 @@ function trackToolUse(session, toolName) {
   session.totalToolCalls++;
 }
 
+// ── Delegation advisor ──────────────────────────────────────────────────────
+// A long run of Read/Grep/Glob with zero edits is exploration — and every one
+// of those results sits in the MAIN context forever. A subagent does the same
+// exploration in its own context, which is discarded; only the summary comes
+// back. Detect the pattern live and suggest delegating, once per session.
+
+const EXPLORE_STREAK_CALLS = 12;
+const EXPLORE_STREAK_TOKENS = 20_000;
+
+/** Update the read-only exploration streak. Returns true when it's time to
+ *  suggest delegation (fires at most once per session). Pure on `session`. */
+export function updateExploreStreak(session, toolName, tokensAdded = 0) {
+  if (!session.explore) session.explore = { streak: 0, streakTokens: 0, advised: false };
+  const e = session.explore;
+  if (toolName === 'Read' || toolName === 'Grep' || toolName === 'Glob') {
+    e.streak++;
+    e.streakTokens += tokensAdded;
+  } else if (toolName === 'Edit' || toolName === 'Write' || toolName === 'Agent') {
+    // An edit means the exploration paid off; an Agent call means the user's
+    // Claude is already delegating. Either way — reset.
+    e.streak = 0;
+    e.streakTokens = 0;
+  }
+  if (!e.advised && e.streak >= EXPLORE_STREAK_CALLS && e.streakTokens >= EXPLORE_STREAK_TOKENS) {
+    e.advised = true;
+    return true;
+  }
+  return false;
+}
+
 // ── Data pruning ────────────────────────────────────────────────────────────
 
 function prunePatterns(patterns) {
@@ -915,6 +945,25 @@ async function main() {
         trackToolUse(session, `Agent:${toolInput.subagent_type || 'general'}`);
       }
 
+      // ── Delegation advisor ──
+      {
+        let tokensAdded = 0;
+        if (toolName === 'Read') {
+          const fp = toolInput.file_path || '';
+          tokensAdded = (session.files[fp] && session.files[fp].estTokens) || 0;
+        } else if (toolName === 'Grep' || toolName === 'Glob') {
+          tokensAdded = 200; // result listings are small but not free
+        }
+        if (updateExploreStreak(session, toolName, tokensAdded)) {
+          const e = session.explore;
+          emitNotice(sessionId, {
+            kind: 'delegate',
+            text: `[cco] ${e.streak} read/search calls in a row, no edits (~${formatTokens(e.streakTokens)} tokens now pinned in main context). ` +
+              `Broad exploration is cheaper in a subagent (Explore/general-purpose): its context is discarded, only the conclusion returns.`,
+          });
+        }
+      }
+
       // ── Live session mini-stats (every 15 tool calls) ──
       if (session.totalToolCalls > 0 && session.totalToolCalls % 15 === 0) {
         try {
@@ -1037,3 +1086,4 @@ if (isMainModule(import.meta.url)) {
 
 // Exposed for tests
 export { trackSearch, trackToolUse };
+// (updateExploreStreak is exported at its definition)

--- a/src/transcript-usage.js
+++ b/src/transcript-usage.js
@@ -38,6 +38,69 @@ export function parseUsageFromLines(lines) {
   return null;
 }
 
+/**
+ * Full-session cache economics from every assistant usage record, in order.
+ * Pure — exported for tests.
+ *
+ * Returns { turns, totals: {input, cacheRead, cacheCreation, output}, breaks }.
+ * A cache BREAK is a turn where the previously-cached context stopped being
+ * read from cache (gap > cache TTL, mid-session system-prompt change, model
+ * switch): cache_read drops far below the previous turn's cached total and the
+ * whole context is re-written at the 1.25× write rate. `lostTokens` is the
+ * cached prefix that had to be paid for again.
+ */
+export function parseEconomicsFromLines(lines) {
+  const totals = { input: 0, cacheRead: 0, cacheCreation: 0, output: 0 };
+  const breaks = [];
+  let turns = 0;
+  let prevCached = 0;
+
+  for (const line of lines) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    const u = obj && obj.message && obj.message.usage;
+    if (!u || typeof u.input_tokens !== 'number') continue;
+
+    const cacheRead = u.cache_read_input_tokens || 0;
+    const cacheCreation = u.cache_creation_input_tokens || 0;
+    turns++;
+    totals.input += u.input_tokens || 0;
+    totals.cacheRead += cacheRead;
+    totals.cacheCreation += cacheCreation;
+    totals.output += u.output_tokens || 0;
+
+    // Warm cache suddenly went cold: >20K was cached, but this turn read back
+    // less than half of it. (Threshold filters out normal turn-to-turn noise.)
+    if (prevCached > 20_000 && cacheRead < prevCached * 0.5) {
+      breaks.push({ turn: turns, lostTokens: prevCached - cacheRead });
+      prevCached = cacheRead + cacheCreation; // prefix restarts from this turn
+    } else {
+      prevCached = Math.max(prevCached, cacheRead + cacheCreation);
+    }
+  }
+
+  return turns > 0 ? { turns, totals, breaks } : null;
+}
+
+/** Read full-session economics from a transcript file. Null on any failure. */
+export function readTranscriptEconomics(transcriptPath, maxBytes = 64 * 1024 * 1024) {
+  if (!transcriptPath) return null;
+  try {
+    const fd = openSync(transcriptPath, 'r');
+    try {
+      const size = fstatSync(fd).size;
+      if (size === 0 || size > maxBytes) return null;
+      const buf = Buffer.alloc(size);
+      readSync(fd, buf, 0, size, 0);
+      return parseEconomicsFromLines(buf.toString('utf-8').split('\n').filter(Boolean));
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return null;
+  }
+}
+
 /** Read real usage from a transcript file, tail-only. Null on any failure. */
 export function readRealUsage(transcriptPath, tailBytes = 256 * 1024) {
   if (!transcriptPath) return null;

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,6 +72,33 @@ export function getModelCost(model) {
   return MODEL_COSTS[model] || MODEL_COSTS.opus;
 }
 
+// ── Prompt-cache pricing ─────────────────────────────────────────────────────
+// Cache reads bill at 10% of the input price; 5-minute cache writes at 125%.
+// Real Claude Code sessions are dominated by cache reads, so pricing every
+// input token at the full rate overstates cost by up to ~10×.
+export const CACHE_READ_MULT = 0.1;
+export const CACHE_WRITE_MULT = 1.25;
+
+/**
+ * Dollar cost of a session given exact usage totals from the transcript.
+ * `totals` = { input, cacheRead, cacheCreation, output } (tokens).
+ * Returns { real, naive, cacheSavings } — `naive` prices all input-side tokens
+ * at the full input rate (what the cost would be without prompt caching).
+ */
+export function computeCacheAwareCost(totals, model) {
+  const c = getModelCost(model);
+  const inRate = c.input / 1e6;
+  const real =
+    (totals.input || 0) * inRate +
+    (totals.cacheRead || 0) * inRate * CACHE_READ_MULT +
+    (totals.cacheCreation || 0) * inRate * CACHE_WRITE_MULT +
+    (totals.output || 0) * (c.output / 1e6);
+  const naive =
+    ((totals.input || 0) + (totals.cacheRead || 0) + (totals.cacheCreation || 0)) * inRate +
+    (totals.output || 0) * (c.output / 1e6);
+  return { real, naive, cacheSavings: Math.max(0, naive - real) };
+}
+
 export function getModelContextWindow(model) {
   return getModelCost(model).contextWindow;
 }
@@ -197,6 +224,44 @@ export function loadConfig() {
 
 export function saveConfig(config) {
   saveJSON(CONFIG_FILE, { ...DEFAULT_CONFIG, ...config });
+}
+
+// ── Estimate self-calibration ────────────────────────────────────────────────
+// The chars-per-token heuristic drifts per codebase (dense JSON vs airy MD).
+// Sessions where the transcript gave ground truth teach us the local drift:
+// at session end we EMA the real/estimated ratio into config, and the budget
+// hook multiplies its estimates by it. Estimates get more honest by themselves.
+
+/** One EMA step of the calibration factor. Pure — exported for tests. */
+export function emaCalibration(prevFactor, ratio, alpha = 0.3) {
+  const clamped = Math.min(2, Math.max(0.5, ratio));
+  const next = (prevFactor || 1) * (1 - alpha) + clamped * alpha;
+  return Math.round(Math.min(2, Math.max(0.5, next)) * 100) / 100;
+}
+
+let _calibrationFactor = null;
+export function getCalibrationFactor() {
+  if (_calibrationFactor !== null) return _calibrationFactor;
+  const cfg = loadJSON(CONFIG_FILE);
+  const f = cfg && cfg.calibration && cfg.calibration.factor;
+  _calibrationFactor = (typeof f === 'number' && f >= 0.5 && f <= 2) ? f : 1;
+  return _calibrationFactor;
+}
+
+/**
+ * Learn from one finished session. Only trusts sessions big enough for the
+ * ratio to be signal, not noise. Returns the new factor or null if skipped.
+ */
+export function updateCalibrationFromSession(realTokens, estimatedTokens) {
+  if (!(realTokens > 20_000) || !(estimatedTokens > 5_000)) return null;
+  const config = loadConfig();
+  const prev = (config.calibration && config.calibration.factor) || 1;
+  const samples = (config.calibration && config.calibration.samples) || 0;
+  const factor = emaCalibration(prev, realTokens / estimatedTokens);
+  config.calibration = { factor, samples: samples + 1, updatedAt: new Date().toISOString() };
+  saveConfig(config);
+  _calibrationFactor = factor;
+  return factor;
 }
 
 /**

--- a/tests/test.js
+++ b/tests/test.js
@@ -12,7 +12,11 @@ import {
   getEffectiveBudget, categorizeFile, shouldSkipFile, shouldIgnoreForTracking,
   isMainModule, getFileLines
 } from '../src/utils.js';
-import { analyzePrompt, buildImprovedPrompt } from '../src/prompt-coach.js';
+import { analyzePrompt, buildImprovedPrompt, classifyPrompt } from '../src/prompt-coach.js';
+import { parseBaselineFromLines } from '../src/overhead.js';
+import { buildIgnoreSuggestions } from '../src/context-shield.js';
+import { updateExploreStreak } from '../src/tracker.js';
+import { computeCacheAwareCost, emaCalibration } from '../src/utils.js';
 import {
   emptyState, addTask, completeActiveTask, getActiveTask, taskSpend, tasksForProject
 } from '../src/tasks.js';
@@ -25,7 +29,7 @@ import {
   isContextIgnored, _globToRegex, _parseIgnoreFile, clearContextIgnoreCache
 } from '../src/contextignore.js';
 import { writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs';
-import { parseUsageFromLines, readRealUsage } from '../src/transcript-usage.js';
+import { parseUsageFromLines, readRealUsage, parseEconomicsFromLines } from '../src/transcript-usage.js';
 import { acquireFileLock } from '../src/utils.js';
 import { trackSearch, trackToolUse } from '../src/tracker.js';
 
@@ -1471,5 +1475,175 @@ describe('tracker helpers', () => {
     assert.equal(session.tools.Read.calls, 2);
     assert.equal(session.tools.Grep.calls, 1);
     assert.equal(session.totalToolCalls, 3);
+  });
+});
+
+// ── v4.3.0: prompt classification (chat / question / task) ──────────────────
+
+describe('classifyPrompt', () => {
+  it('classifies conversational replies as chat (en + ru)', () => {
+    assert.equal(classifyPrompt('а те все хорошо ))'), 'chat');
+    assert.equal(classifyPrompt('спасибо, отлично!'), 'chat');
+    assert.equal(classifyPrompt('ok great'), 'chat');
+    assert.equal(classifyPrompt('да'), 'chat');
+    assert.equal(classifyPrompt('понял, спасибо большое, очень круто получилось'), 'chat');
+    assert.equal(classifyPrompt(''), 'chat');
+  });
+
+  it('classifies questions as question, even short ones', () => {
+    assert.equal(classifyPrompt('а почему и откуда появился этот контрибьютор?'), 'question');
+    assert.equal(classifyPrompt('how does the read cache work?'), 'question');
+    assert.equal(classifyPrompt('как мы можем еще улучшить наш оптимизатор'), 'question');
+  });
+
+  it('classifies work requests as task (imperatives beat question shape)', () => {
+    assert.equal(classifyPrompt('давай все сделай и релизни тоже ))'), 'task');
+    assert.equal(classifyPrompt('добавь функцию в src/utils.js'), 'task');
+    assert.equal(classifyPrompt('fix the login bug in src/auth.ts'), 'task');
+    assert.equal(classifyPrompt('почини ошибку TypeError в трекере'), 'task');
+    assert.equal(classifyPrompt('что сделай чтобы починить'), 'task');
+  });
+
+  it('detects Russian strong verbs despite ASCII-only \\b', () => {
+    const a = analyzePrompt('исправь баг в src/tracker.js чтобы тесты проходили');
+    assert.equal(a.signals.hasStrongVerb, true);
+    assert.equal(a.signals.hasSuccess, true);
+  });
+});
+
+// ── v4.3.0: cache economics ──────────────────────────────────────────────────
+
+describe('cache economics', () => {
+  const econLine = (inp, cr, cc, out) => JSON.stringify({
+    message: { usage: {
+      input_tokens: inp, cache_read_input_tokens: cr,
+      cache_creation_input_tokens: cc, output_tokens: out,
+    } }
+  });
+
+  it('totals usage across all turns', () => {
+    const e = parseEconomicsFromLines([econLine(10, 0, 30000, 500), econLine(10, 30000, 5000, 400)]);
+    assert.equal(e.turns, 2);
+    assert.deepEqual(e.totals, { input: 20, cacheRead: 30000, cacheCreation: 35000, output: 900 });
+    assert.equal(e.breaks.length, 0);
+  });
+
+  it('detects a cache break when warm cache goes cold', () => {
+    const e = parseEconomicsFromLines([
+      econLine(10, 0, 30000, 500),
+      econLine(10, 30000, 5000, 400),
+      econLine(10, 2000, 33000, 300), // read 2K << 35K cached → break
+    ]);
+    assert.equal(e.breaks.length, 1);
+    assert.equal(e.breaks[0].turn, 3);
+    assert.equal(e.breaks[0].lostTokens, 33000);
+  });
+
+  it('does not flag small caches as breaks (noise threshold)', () => {
+    const e = parseEconomicsFromLines([econLine(10, 0, 15000, 100), econLine(10, 0, 15000, 100)]);
+    assert.equal(e.breaks.length, 0);
+  });
+
+  it('returns null with no usage records', () => {
+    assert.equal(parseEconomicsFromLines(['{"a":1}', 'junk']), null);
+  });
+
+  it('computeCacheAwareCost prices reads at 10% and writes at 125%', () => {
+    const c = computeCacheAwareCost(
+      { input: 1000, cacheRead: 1_000_000, cacheCreation: 100_000, output: 10_000 }, 'opus-4.8');
+    // 0.001*5 + 1*5*0.1 + 0.1*5*1.25 + 0.01*25 = 1.38
+    assert.ok(Math.abs(c.real - 1.38) < 1e-9);
+    assert.ok(Math.abs(c.naive - 5.755) < 1e-9);
+    assert.ok(Math.abs(c.cacheSavings - 4.375) < 1e-9);
+  });
+});
+
+// ── v4.3.0: session baseline overhead ───────────────────────────────────────
+
+describe('overhead baseline', () => {
+  it('takes the FIRST assistant usage (context before any work)', () => {
+    const line = (inp, cr, cc) => JSON.stringify({ message: { usage: {
+      input_tokens: inp, cache_read_input_tokens: cr, cache_creation_input_tokens: cc, output_tokens: 1 } } });
+    const baseline = parseBaselineFromLines([
+      '{"type":"user"}',
+      line(10, 0, 45000),   // first response: 45K baseline
+      line(10, 45000, 9000) // later turns must not win
+    ]);
+    assert.equal(baseline, 45010);
+  });
+
+  it('returns null when the transcript has no usage', () => {
+    assert.equal(parseBaselineFromLines(['{"x":1}']), null);
+  });
+});
+
+// ── v4.3.0: .contextignore suggestions ──────────────────────────────────────
+
+describe('buildIgnoreSuggestions', () => {
+  const patterns = { projects: {
+    '/proj': { wastedReads: {
+      '/proj/README.md': { sessions: 5, totalTokensWasted: 12000 },
+      '/proj/docs/big.md': { sessions: 3, totalTokensWasted: 8000 },
+      '/proj/rare.txt': { sessions: 1, totalTokensWasted: 100 },
+      '/other/x.md': { sessions: 9, totalTokensWasted: 999 },
+    } },
+  } };
+
+  it('suggests project-relative patterns for 3+ session waste, sorted by tokens', () => {
+    const s = buildIgnoreSuggestions(patterns, '/proj');
+    assert.deepEqual(s.map(x => x.pattern), ['README.md', 'docs/big.md']);
+  });
+
+  it('dedupes against existing .contextignore lines', () => {
+    const s = buildIgnoreSuggestions(patterns, '/proj', ['docs/big.md', '# comment']);
+    assert.deepEqual(s.map(x => x.pattern), ['README.md']);
+  });
+
+  it('never suggests files from other projects', () => {
+    const s = buildIgnoreSuggestions(patterns, '/proj');
+    assert.ok(!s.some(x => x.pattern.includes('..')));
+  });
+});
+
+// ── v4.3.0: estimate self-calibration ───────────────────────────────────────
+
+describe('emaCalibration', () => {
+  it('moves 30% toward the observed ratio', () => {
+    assert.equal(emaCalibration(1, 1.5), 1.15);
+  });
+
+  it('clamps wild ratios to [0.5, 2]', () => {
+    assert.equal(emaCalibration(1, 50), 1.3);   // ratio clamped to 2
+    assert.equal(emaCalibration(1, 0.01), 0.85); // ratio clamped to 0.5
+  });
+
+  it('keeps a neutral factor neutral', () => {
+    assert.equal(emaCalibration(1, 1), 1);
+  });
+});
+
+// ── v4.3.0: delegation advisor ──────────────────────────────────────────────
+
+describe('updateExploreStreak', () => {
+  it('advises once at 12 read-only calls and 20K tokens', () => {
+    const s = {};
+    for (let i = 0; i < 11; i++) assert.equal(updateExploreStreak(s, 'Read', 2000), false);
+    assert.equal(updateExploreStreak(s, 'Read', 2000), true);
+    assert.equal(updateExploreStreak(s, 'Read', 2000), false); // once per session
+  });
+
+  it('does not advise on many calls with few tokens', () => {
+    const s = {};
+    for (let i = 0; i < 30; i++) assert.equal(updateExploreStreak(s, 'Grep', 100), false);
+  });
+
+  it('resets on Edit/Write/Agent', () => {
+    for (const reset of ['Edit', 'Write', 'Agent']) {
+      const s = {};
+      for (let i = 0; i < 10; i++) updateExploreStreak(s, 'Read', 5000);
+      updateExploreStreak(s, reset);
+      assert.equal(s.explore.streak, 0);
+      assert.equal(s.explore.streakTokens, 0);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Six upgrades aimed at one goal: make the optimizer measure what actually bills and stop it from ever being the noise it fights.

### 1. Prompt Coach stops grading conversation (trust fix)
New `classifyPrompt()`: prompts are **chat / question / task**. Conversational replies ("спасибо, всё ок") are no longer graded F with "name the file you want changed" injected into context. Questions are logged but never coached; short follow-ups lean on loaded context. **Russian support** added — and fixed a latent bug: JS `\b` is ASCII-only, so Cyrillic verb matching silently never worked.

### 2. Cache economics — the real billing lever
Session cost now priced at **real prompt-cache rates** (reads 10%, writes 125% of input) from exact transcript usage. New Cache line on `/cco`:

```
Cache    ▓▓▓▓▓▓▓▓▓▓▓░  93% hit  ·  saved $90.36 vs uncached  ·  9 breaks (−$5.31)
```

Cache **breaks** (>5 min pause, mid-session CLAUDE.md edit, model switch) are detected and priced — nobody else surfaces this.

### 3. NEW `/cco-overhead` — session baseline audit
Measures the fixed context every session starts with, from ground-truth first-turn usage. Real output on this repo: baseline **52K tokens (52% of budget)**, including 46 user agents ≈ 15.8K.

### 4. `/cco-shield suggest|apply`
Files wasted in 3+ sessions become `.contextignore` rules with one command — observation closes into a permanent rule.

### 5. Self-calibrating estimates
Real/estimated ratio EMA'd into config at session end (clamped 0.5–2×); the budget hook applies the factor. The heuristic learns each codebase's drift.

### 6. Delegation advisor
12+ consecutive Read/Grep/Glob with no edits and 20K+ tokens pinned → one-per-session hint to fan exploration out to a subagent.

## Tests
150 → 170, all passing. New coverage: classification (ru/en), break detection, cache cost math, baseline parsing, ignore suggestions, calibration EMA, streak advisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)