### PR TITLE
chore(sync-version): warn when the external claude-plugins marketplace is stale

### DIFF
--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -6,6 +6,10 @@
  *   - .claude-plugin/marketplace.json (plugins[].version + description)
  *   - docs/index.html                 (footer "vX.Y.Z" badge)
  * Run before publish: npm run sync-version
+ *
+ * Also CHECKS (can't write — different repo) the external marketplace
+ * egorfedorov/claude-plugins, which pins its own copy of the version and sat
+ * two releases stale once. Warns on mismatch; best-effort on network failure.
  */
 
 import { readFileSync, writeFileSync } from 'fs';
@@ -56,3 +60,20 @@ if (synced !== html) {
 }
 
 if (!changed) console.log(`✓ versions already in sync: ${pkg.version}`);
+
+// External marketplace repo — read-only check, never fails the run.
+const EXT = 'egorfedorov/claude-plugins';
+try {
+  const res = await fetch(
+    `https://raw.githubusercontent.com/${EXT}/main/.claude-plugin/marketplace.json`,
+    { signal: AbortSignal.timeout(4000) }
+  );
+  const ext = (await res.json()).plugins?.find(p => p.name === pkg.name);
+  if (ext && ext.version !== pkg.version) {
+    console.log(`⚠ ${EXT} still lists v${ext.version} — bump its .claude-plugin/marketplace.json to v${pkg.version}`);
+  } else if (ext) {
+    console.log(`✓ ${EXT} marketplace in sync: v${ext.version}`);
+  }
+} catch {
+  console.log(`? could not check ${EXT} (offline?) — verify its marketplace.json manually`);
+}


### PR DESCRIPTION
sync-version now checks the external `egorfedorov/claude-plugins` marketplace (read-only, best-effort with a 4s timeout) and warns if its pinned version lags package.json — it silently sat two releases stale until v4.3.0.

Verified locally:
```
✓ versions already in sync: 4.3.0
✓ egorfedorov/claude-plugins marketplace in sync: v4.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)