### PR TITLE
fix: v4.7.0 — Windows-correct path handling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
   "plugins": [
     {
       "name": "claude-context-optimizer",
-      "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach",
-      "version": "4.3.0",
+      "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach — now Windows-correct",
+      "version": "4.7.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.6.0",
-  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach",
+  "version": "4.7.0",
+  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach — now Windows-correct",
   "author": {
     "name": "Egor Fedorov"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 4.7.0 — 2026-08-05
+
+### Windows: the path handling was wrong everywhere it mattered
+CCO assumed POSIX. On Windows that silently degraded four separate features —
+none of them loudly enough to look broken.
+
+- **`/cco-overhead` finds transcripts again** (#46). `projectTranscriptDir()`
+  munged only `/` and `.`, so a Windows cwd kept its `\`, `:` and spaces and
+  produced a malformed lookup path
+  (`~\.claude\projects\C:\Program Files\Git`). Claude Code names that folder
+  `C--Program-Files-Git`; the encoding now matches. This also un-breaks the
+  CLAUDE.md / MEMORY.md itemization, which had been lumping everything into
+  the "system prompt & tools (unattributed)" line.
+- **`.contextignore` matches CRLF files** (#33). Patterns were parsed with
+  `split('\n')`, leaving a trailing `\r` on every line of a Windows-authored
+  file — so *no pattern ever matched* and the whole ignore list was inert.
+  Now `split(/\r?\n/)`.
+- **Glob matching understands backslashes** (#33). Paths are normalized to `/`
+  before matching, so `C:\proj\dist\a.js` matches `dist/**`.
+- **`getProjectRoot()` walks up correctly** (#33). The parent-directory step
+  was a `/`-only regex that never terminated properly on `C:\`; it now uses
+  `path.dirname`.
+- **`displayPath()` shortens Windows paths.** Splitting on `/` treated
+  `C:\a\b\c\file.ts` as one segment, so nothing was truncated and raw absolute
+  paths leaked into every report.
+- New `toPosixPath()` helper in `src/utils.js` — one normalization point at the
+  boundary instead of two separator dialects in every matcher.
+
+### Docs
+- `CONTRIBUTING.md` (#40) — setup, the release checklist, and the platform
+  rules above, so the POSIX assumption doesn't creep back in.
+
+### Tests
+175 → 183. Covers the Windows transcript-folder encoding, CRLF/LF parse
+equivalence, backslash path display, and `toPosixPath`.
+
+
 ## 4.6.0 — 2026-07-06
 
 ### /cco-overhead mcp — observation → the exact removal command

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for helping make the ledger more honest.
+
+## The bar
+
+Every change should make **a number more true, a waste more visible, or a fix
+more automatic**. Concretely:
+
+1. **Honesty first.** Never report a number we can't defend. Prefer transcript
+   ground truth over estimates, and NET savings over gross.
+2. **Silence is a feature.** Hooks stay under ~10ms and inject nothing that
+   isn't actionable.
+3. **No dependencies.** CCO is Node built-ins only, and stays that way.
+4. **Tests for new pure logic.** CI runs Node 18/20/22 plus CodeQL.
+
+## Setup
+
+```bash
+git clone https://github.com/egorfedorov/claude-context-optimizer
+cd claude-context-optimizer
+node tests/test.js      # no install step — zero dependencies
+```
+
+Most modules are runnable directly for a smoke test:
+
+```bash
+node src/overhead.js        # session baseline audit
+node src/dashboard.js       # /cco screen
+```
+
+## Making a change
+
+- Branch off `main` (`fix/…`, `feat/…`, `docs/…`), open a PR against `main`.
+- Keep pure logic exported and covered in `tests/test.js` — the hook entry
+  points are guarded by `isMainModule()` precisely so tests can import them
+  without the module blocking on stdin.
+- Update `CHANGELOG.md` under an `## Unreleased` heading for user-visible
+  changes.
+- Reference the issue you're closing (`Closes #NN`).
+
+## Platform notes
+
+CCO runs on macOS, Linux and Windows. When touching paths:
+
+- Use `toPosixPath()` from `src/utils.js` before splitting or glob-matching —
+  Windows hands you `\`.
+- Use `path.dirname` / `path.join`, never a `/`-hardcoded regex, to walk
+  directories.
+- Parse text files with `split(/\r?\n/)`, not `split('\n')` — user-authored
+  files on Windows are CRLF.
+
+## Releasing (maintainers)
+
+1. Bump `version` in `package.json` (single source of truth).
+2. `npm run sync-version` — propagates to `.claude-plugin/plugin.json`,
+   `.claude-plugin/marketplace.json` and `docs/index.html`, and warns if the
+   external `egorfedorov/claude-plugins` marketplace is stale (that repo must
+   be updated separately).
+3. Update `CHANGELOG.md` and the README "What's new" section.
+4. Branch → PR → merge → `git tag vX.Y.Z` → `gh release create`.
+
+## License
+
+Contributions are accepted under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,32 @@ At $5/M input tokens (Opus 4.8), a developer spending $100/month is lighting **$
 
 ---
 
+## What's new in v4.7 — Windows works
+
+CCO quietly assumed POSIX paths. On Windows that broke four things at once, and
+none of them looked broken — they just reported less:
+
+- **`/cco-overhead` said "no session transcripts found"** even with transcripts
+  right there. The cwd → folder encoding dropped `\`, `:` and spaces, so it
+  looked in `~\.claude\projects\C:\Program Files\Git` instead of
+  `…\projects\C--Program-Files-Git`. Fixed — which also restores the
+  CLAUDE.md/memory itemization that had been collapsing into "system prompt &
+  tools (unattributed)". ([#46](https://github.com/egorfedorov/claude-context-optimizer/issues/46))
+- **`.contextignore` was inert on Windows.** CRLF files left a `\r` on every
+  pattern, so not one of them matched. Every lockfile you thought you'd
+  excluded was still being counted. ([#33](https://github.com/egorfedorov/claude-context-optimizer/issues/33))
+- **Globs now understand `\`** — `C:\proj\dist\a.js` matches `dist/**`.
+- **Project-root detection and path display** are separator-aware, so reports
+  stop leaking raw `C:\…` paths.
+
+Plus a [CONTRIBUTING.md](CONTRIBUTING.md) with the platform rules, so this
+doesn't regress. 183 tests, green on Node 18/20/22.
+
+> Hooks still need a POSIX shell (Git Bash or WSL) — native Windows hooks are
+> tracked on the [roadmap](ROADMAP.md).
+
+---
+
 ## What's new in v4.5 — model auto-detection & the dollar leaks
 
 <p align="center">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,11 @@ must make a number more true, a waste more visible, or a fix more automatic.
 - [ ] **Per-model cache TTL awareness** (1h beta cache pricing) in economics
 - [ ] **Subagent economics**: split main-loop vs agent token spend in `/cco`
       and credit delegation savings to the advisor that suggested it
-- [ ] **Windows-native hooks** (drop the POSIX-shell requirement)
+- [x] **Windows-correct paths** — shipped in v4.7.0: transcript-folder
+      encoding, CRLF `.contextignore`, backslash-aware globs, project-root
+      walk and path display (#46, #33)
+- [ ] **Windows-native hooks** (drop the POSIX-shell requirement — the *only*
+      remaining Windows gap; Git Bash/WSL still required)
 
 ## v5.0 — The ecosystem
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -836,7 +836,7 @@
   <div class="container">
     <div class="badge">
       <div class="badge-dot"></div>
-      v4.5.0 &middot; Claude 5 ready &middot; model auto-detect &middot; Benchmarked
+      v4.7.0 &middot; Claude 5 ready &middot; model auto-detect &middot; Benchmarked
     </div>
     <div class="hero-stat">63%</div>
     <h1>fewer tokens. <span class="highlight">Sharper prompts.</span><br>Works with every Claude.</h1>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.6.0",
-  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach",
+  "version": "4.7.0",
+  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach — now Windows-correct",
   "type": "module",
   "main": "src/tracker.js",
   "bin": {

--- a/src/contextignore.js
+++ b/src/contextignore.js
@@ -18,6 +18,7 @@
 import { readFileSync } from 'fs';
 import { join, basename, resolve } from 'path';
 import { homedir } from 'os';
+import { toPosixPath } from './utils.js';
 
 // ── Pattern cache ────────────────────────────────────────────────────────────
 
@@ -37,7 +38,9 @@ function parseIgnoreFile(filePath) {
   }
 
   const patterns = [];
-  for (const rawLine of content.split('\n')) {
+  // Split on CRLF or LF — a Windows-authored .contextignore otherwise leaves a
+  // trailing \r on every pattern, and nothing ever matches.
+  for (const rawLine of content.split(/\r?\n/)) {
     const line = rawLine.trim();
     // Skip blank lines and comments
     if (!line || line.startsWith('#')) continue;
@@ -121,9 +124,11 @@ function globToRegex(pattern) {
  * - Patterns with / or ** are matched against the full normalized path.
  */
 function matchesPattern(filePath, pattern) {
-  const normalized = resolve(filePath);
+  // Patterns are always written with `/`; normalize the path to match so a
+  // Windows `C:\proj\dist\a.js` still matches `dist/**`.
+  const normalized = toPosixPath(resolve(filePath));
   const name = basename(normalized);
-  const raw = pattern.raw;
+  const raw = toPosixPath(pattern.raw);
 
   // Determine match target: basename-only for simple patterns,
   // full path for patterns containing / or **
@@ -138,7 +143,7 @@ function matchesPattern(filePath, pattern) {
     if (regex.test(normalized)) return true;
 
     // Also try matching against a relative-ish path from cwd
-    const cwd = process.cwd();
+    const cwd = toPosixPath(process.cwd());
     if (normalized.startsWith(cwd + '/')) {
       const relative = normalized.slice(cwd.length + 1);
       if (regex.test(relative)) return true;

--- a/src/overhead.js
+++ b/src/overhead.js
@@ -50,9 +50,15 @@ export function parseBaselineFromLines(lines) {
 
 // ── Transcript discovery ─────────────────────────────────────────────────────
 
-/** Claude Code stores transcripts under ~/.claude/projects/<munged-cwd>/. */
+/**
+ * Claude Code stores transcripts under ~/.claude/projects/<munged-cwd>/, where
+ * the munging replaces every path-ish character with '-'. On Windows the cwd
+ * also carries '\', ':' and spaces (`C:\Program Files\Git` becomes
+ * `C--Program-Files-Git`); missing those left the path malformed and every
+ * lookup reported "no session transcripts found".
+ */
 export function projectTranscriptDir(cwd) {
-  return join(homedir(), '.claude', 'projects', cwd.replace(/[/.]/g, '-'));
+  return join(homedir(), '.claude', 'projects', cwd.replace(/[/.:\\ ]/g, '-'));
 }
 
 function recentTranscripts(cwd, limit = 10) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,9 +6,17 @@
  */
 
 import { readFileSync, writeFileSync, renameSync, mkdirSync, rmdirSync, existsSync, statSync, realpathSync, readdirSync } from 'fs';
-import { join, basename, extname } from 'path';
+import { join, basename, extname, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+
+// ── Path normalization ───────────────────────────────────────────────────────
+// Windows hands us `C:\Users\me\proj\src\a.ts`; every glob, split and display
+// helper here reasons in `/`. Normalize once at the boundary rather than
+// teaching each matcher two separator dialects.
+export function toPosixPath(p) {
+  return typeof p === 'string' ? p.replace(/\\/g, '/') : p;
+}
 
 // ── Main-module guard ────────────────────────────────────────────────────────
 // True only when the given module is the process entry point (i.e. run as
@@ -189,6 +197,7 @@ export function displayPath(filePath, maxLen = 35) {
   if (display.startsWith(home)) {
     display = '~' + display.slice(home.length);
   }
+  display = toPosixPath(display);
   const parts = display.split('/');
   if (parts.length > 3) {
     display = parts.slice(-3).join('/');
@@ -498,15 +507,16 @@ export function getFileLines(filePath, maxBytes = 10 * 1024 * 1024) {
 export function getProjectRoot(filePath) {
   try {
     let dir = filePath;
-    // If filePath is a file, walk from its dir
-    try { if (statSync(dir).isFile()) dir = dir.replace(/\/[^/]+$/, ''); } catch { /* ignore */ }
+    // If filePath is a file, walk from its dir. `dirname` is separator-aware,
+    // so this also terminates correctly at `C:\` on Windows, not just `/`.
+    try { if (statSync(dir).isFile()) dir = dirname(dir); } catch { /* ignore */ }
     for (let i = 0; i < 10; i++) {
       if (existsSync(join(dir, '.git'))) return dir;
       if (existsSync(join(dir, 'package.json'))) return dir;
       if (existsSync(join(dir, 'Cargo.toml'))) return dir;
       if (existsSync(join(dir, 'go.mod'))) return dir;
       if (existsSync(join(dir, 'pyproject.toml'))) return dir;
-      const parent = dir.replace(/\/[^/]+$/, '');
+      const parent = dirname(dir);
       if (parent === dir || !parent) break;
       dir = parent;
     }

--- a/tests/test.js
+++ b/tests/test.js
@@ -10,10 +10,10 @@ import {
   BUDGET_CONFIG_FILE, loadJSON,
   MODEL_COSTS, MODEL_INPUT_COST, getModelCost, getModelContextWindow,
   getEffectiveBudget, categorizeFile, shouldSkipFile, shouldIgnoreForTracking,
-  isMainModule, getFileLines
+  isMainModule, getFileLines, toPosixPath
 } from '../src/utils.js';
 import { analyzePrompt, buildImprovedPrompt, classifyPrompt } from '../src/prompt-coach.js';
-import { parseBaselineFromLines } from '../src/overhead.js';
+import { parseBaselineFromLines, projectTranscriptDir } from '../src/overhead.js';
 import { buildIgnoreSuggestions } from '../src/context-shield.js';
 import { updateExploreStreak } from '../src/tracker.js';
 import { computeCacheAwareCost, emaCalibration } from '../src/utils.js';
@@ -124,6 +124,29 @@ describe('utils', () => {
       const result = displayPath(home + '/projects/foo/bar.ts');
       assert.ok(result.startsWith('~') || !result.includes(home),
         'should replace homedir with ~');
+    });
+
+    // Issue #33: on Windows the whole path is one segment under split('/'),
+    // so nothing was ever shortened and the raw C:\... path leaked into output.
+    it('truncates Windows-style backslash paths to last 3 segments', () => {
+      assert.equal(displayPath('C:\\a\\b\\c\\d\\e\\file.ts'), 'd/e/file.ts');
+    });
+  });
+
+  describe('toPosixPath', () => {
+    it('converts backslash separators to forward slashes', () => {
+      assert.equal(toPosixPath('C:\\Users\\me\\proj\\src\\a.ts'),
+        'C:/Users/me/proj/src/a.ts');
+    });
+
+    it('leaves POSIX paths untouched', () => {
+      assert.equal(toPosixPath('/Users/me/proj/src/a.ts'),
+        '/Users/me/proj/src/a.ts');
+    });
+
+    it('passes through non-strings unchanged', () => {
+      assert.equal(toPosixPath(undefined), undefined);
+      assert.equal(toPosixPath(null), null);
     });
   });
 
@@ -390,6 +413,25 @@ describe('contextignore', () => {
     it('returns empty array for non-existent file', () => {
       const result = _parseIgnoreFile('/tmp/nonexistent-contextignore-' + Date.now());
       assert.deepEqual(result, []);
+    });
+
+    // Issue #33: a Windows-authored .contextignore is CRLF; a trailing \r on
+    // every pattern made all of them silently fail to match.
+    it('parses CRLF and LF files identically', () => {
+      const body = '# comment\n*.lock\n\ndist/**\n';
+      const lf = join('/tmp', `cco-ignore-lf-${process.pid}`);
+      const crlf = join('/tmp', `cco-ignore-crlf-${process.pid}`);
+      writeFileSync(lf, body);
+      writeFileSync(crlf, body.replace(/\n/g, '\r\n'));
+      try {
+        const rawsLf = _parseIgnoreFile(lf).map(p => p.raw);
+        const rawsCrlf = _parseIgnoreFile(crlf).map(p => p.raw);
+        assert.deepEqual(rawsLf, ['*.lock', 'dist/**']);
+        assert.deepEqual(rawsCrlf, rawsLf);
+      } finally {
+        unlinkSync(lf);
+        unlinkSync(crlf);
+      }
     });
   });
 
@@ -1574,6 +1616,25 @@ describe('overhead baseline', () => {
 
   it('returns null when the transcript has no usage', () => {
     assert.equal(parseBaselineFromLines(['{"x":1}']), null);
+  });
+
+  // Issue #46: Claude Code munges '\', ':' and spaces to '-' as well, so a
+  // Windows cwd produced a malformed path and "no session transcripts found".
+  describe('projectTranscriptDir', () => {
+    const folder = cwd => basename(projectTranscriptDir(cwd));
+
+    it('encodes a Windows cwd the way Claude Code names the folder', () => {
+      assert.equal(folder('C:\\Program Files\\Git'), 'C--Program-Files-Git');
+    });
+
+    it('still encodes a POSIX cwd unchanged', () => {
+      assert.equal(folder('/Users/me/dev/my.app'), '-Users-me-dev-my-app');
+    });
+
+    it('roots the folder under ~/.claude/projects', () => {
+      assert.ok(projectTranscriptDir('/a/b')
+        .startsWith(join(homedir(), '.claude', 'projects')));
+    });
   });
 });
 


### PR DESCRIPTION
CCO assumed POSIX paths. On Windows that broke four features at once — and none of them looked broken, they just reported less.

## Fixes

| Issue | Symptom on Windows | Fix |
|---|---|---|
| #46 | `/cco-overhead` reports "No session transcripts found"; CLAUDE.md/memory itemization collapses into the unattributed line | `projectTranscriptDir()` munges `\`, `:` and spaces to `-` the way Claude Code names the folder (`C:\Program Files\Git` → `C--Program-Files-Git`) |
| #33 | `.contextignore` is completely inert — CRLF leaves `\r` on every pattern, so none match | `split(/\r?\n/)` |
| #33 | `C:\proj\dist\a.js` doesn't match `dist/**` | paths normalized via new `toPosixPath()` in `src/utils.js` |
| #33 | `getProjectRoot()` parent walk is a `/`-only regex, never terminates properly at `C:\` | `path.dirname` |
| — | `displayPath()` treats `C:\a\b\c\file.ts` as one segment, so raw absolute paths leak into reports | normalize before split |
| #40 | no contributor docs | `CONTRIBUTING.md` — setup, release checklist, platform rules so the POSIX assumption doesn't creep back |

## Verification

- `node tests/test.js` — **183 pass, 0 fail** (was 175). New coverage: Windows transcript-folder encoding, CRLF/LF parse equivalence, backslash path display, `toPosixPath`.
- Smoke-tested `overhead.js`, `dashboard.js`, `doctor.js` on macOS — POSIX behaviour unchanged (`/Users/…` still encodes identically).

## Also

`.claude-plugin/marketplace.json` was stale at **4.3.0** — it missed the 4.5.0 and 4.6.0 releases. `npm run sync-version` brought it to 4.7.0.

> Note: hooks still require a POSIX shell (Git Bash/WSL) on Windows. Native Windows hooks remain on the roadmap — this PR fixes path *handling*, not the shell requirement.

Closes #46
Closes #33
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)