### PR TITLE
feat: v4.8.0 — per-language estimates, /cco-config, decision logic under test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
   "plugins": [
     {
       "name": "claude-context-optimizer",
-      "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach — now Windows-correct",
-      "version": "4.7.0",
+      "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach, per-language token estimation, tunable thresholds via /cco-config",
+      "version": "4.8.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.7.0",
-  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach — now Windows-correct",
+  "version": "4.8.0",
+  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach, per-language token estimation, tunable thresholds via /cco-config",
   "author": {
     "name": "Egor Fedorov"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm test
+
+  versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      # Fails if package.json, plugin.json, marketplace.json or the docs badge
+      # disagree. marketplace.json shipped two releases stale before this ran.
+      - run: node scripts/sync-version.js --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## 4.8.0 — 2026-08-05
+
+### Per-language token estimation (#35)
+The headline "tokens saved" figure was built on a single constant:
+`AVG_CHARS_PER_LINE = 35`, applied to every file type. Chars-per-line is what
+turns an observed line count into a token estimate, so a flat value biased the
+central metric per file.
+
+- New `CHARS_PER_LINE` map, **measured over 6,344 real source files** rather
+  than guessed. The measurement contradicted the issue's own estimates: `.json`
+  is 38.8 chars/line (not 18–22) and `.md` is 35.8 (not 45–60).
+- The corrections that matter: `.svg` averages **100.5** chars/line — nearly 3x
+  the old assumption, so generated SVG was massively under-counted. `.css` is
+  **25.3** and `.txt` **27.8** (over-counted); `.ts` is **44** and `.sql` **46**
+  (under-counted).
+- Applies to the big-file size shortcut in `getFileLines` too, so a 5MB SVG is
+  no longer counted as if its lines were 35 chars long.
+- Overridable per extension via `config.charsPerLine`.
+- This is complementary to the existing self-calibration, not redundant: the
+  EMA factor corrects *aggregate session* drift and cannot fix *per-file* bias.
+
+### Tunable thresholds + `/cco-config` (#39)
+Eleven behavior knobs were hardcoded across four modules. They are now
+`thresholds` in `config.json`, with a new `/cco-config show|get|set|reset`.
+
+- Every value is range-validated. An out-of-range or misspelled entry is
+  ignored in favour of the default and flagged with `!` in the table — a typo
+  can never make a hook behave wildly.
+- Covers re-read warning points, Read-Cache staleness (tokens/files/time),
+  prompt-coach length bands, and the `/cco-pack` budget cap.
+- `CCO_STALE_TIME_MS` still overrides `staleTimeMs` for one-off experiments.
+
+### Decision logic under test (#36)
+The formatters had coverage; the logic that decides what reaches Claude's
+context did not. Extracted the pure decision cores out of `main()` bodies that
+read stdin and call `process.exit`, then covered them:
+
+- `budget.js` — `selectWarnings` (each threshold fires exactly once, ascending
+  on a jump, boundary-inclusive), `shouldWarnCacheBreak`, `shouldWarnContextRot`,
+  `buildCompactRecommendation`.
+- `read-cache.js` — `checkStaleness` is now exported with injectable clock and
+  thresholds; table-driven tests over token/file/time displacement.
+- `tracker.js` — `aggregateSessionFiles` and `buildCoOccurrence` extracted;
+  `finalizeSession` now calls them instead of duplicating the logic inline.
+
+Writing these caught that a *deliberate re-read scores as useful*, not waste —
+worth pinning, since it directly shapes the reported waste percentage.
+
+### CI: version drift can't ship again
+`.claude-plugin/marketplace.json` silently sat at 4.3.0 through the 4.5.0 and
+4.6.0 releases. `sync-version.js --check` writes nothing and exits non-zero on
+any drift between `package.json`, `plugin.json`, `marketplace.json` and the
+docs badge; CI runs it on every push and PR.
+
+### Tests
+183 → 238.
+
+
 ## 4.7.0 — 2026-08-05
 
 ### Windows: the path handling was wrong everywhere it mattered

--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ At $5/M input tokens (Opus 4.8), a developer spending $100/month is lighting **$
 
 ---
 
+## What's new in v4.8 — the metric gets honest, the knobs come out
+
+- **Token estimates are per-language now.** The headline "tokens saved" number
+  was computed from one constant — 35 chars per line, for every file type. So I
+  measured **6,344 real source files** instead of guessing. `.svg` averages
+  **100.5** chars/line (nearly 3x under-counted before), `.css` **25.3** and
+  `.txt` **27.8** (over-counted), `.ts` **44**. Notably the measurement
+  contradicted my own priors: `.json` is 38.8, not the ~20 I expected.
+  ([#35](https://github.com/egorfedorov/claude-context-optimizer/issues/35))
+- **`/cco-config` — 11 hardcoded knobs, now tunable.** Re-read warning points,
+  Read-Cache staleness, prompt-coach length bands, `/cco-pack` budget cap. Every
+  value range-validated: a typo is ignored in favour of the default and flagged,
+  never silently applied.
+  ([#39](https://github.com/egorfedorov/claude-context-optimizer/issues/39))
+- **The decision logic is under test.** The formatters had coverage; the code
+  that decides what actually reaches your context didn't. Budget gating,
+  cache-break detection, Read-Cache staleness and session waste classification
+  are now pure, exported, and covered — **238 tests**, up from 183.
+  ([#36](https://github.com/egorfedorov/claude-context-optimizer/issues/36))
+- **Version drift can't ship again.** `marketplace.json` quietly sat two
+  releases behind; CI now fails on any mismatch.
+
+---
+
 ## What's new in v4.7 — Windows works
 
 CCO quietly assumed POSIX paths. On Windows that broke four things at once, and
@@ -534,6 +558,38 @@ When installed as a plugin, commands are namespaced: `/claude-context-optimizer:
 | `/cco-coach [prompt]` | **NEW** — Prompt quality score (S/A/B/C/D/F) + concrete suggestions to improve |
 | `/cco-pack [task]` | **NEW** — Build optimal context pack for a task: ranked files with offset/limit |
 | `/cco-doctor` | **NEW** — Plugin health check (versions, hooks, data dir, model config) |
+| `/cco-config [show\|get\|set\|reset]` | **NEW** — tune the behavior thresholds below without editing source |
+
+### Tunable thresholds (`/cco-config`)
+
+Stored under `thresholds` in `~/.claude-context-optimizer/config.json`. Every
+value is range-validated; an out-of-range or misspelled entry is ignored in
+favour of the default and flagged with `!` in `/cco-config show`, so a typo
+can never make a hook behave wildly.
+
+| Key | Default | What it changes |
+|---|---|---|
+| `rereadWarnAt` | 3 | reads of an unedited file before the first re-read warning |
+| `rereadEscalateAt` | 5 | reads before the "put it in CLAUDE.md" escalation |
+| `bigFileLines` | 500 | full-read line count that triggers the offset/limit warning |
+| `mediumFileLines` | 200 | full-read line count that triggers the soft hint |
+| `staleTokenRatio` | 0.10 | share of budget loaded after a file before Read Cache re-allows it |
+| `staleFiles` | 8 | other files loaded after a file before it counts as evicted (at 200K) |
+| `staleTimeMs` | 600000 | ms since last read before a cached file counts as stale |
+| `promptMinWords` | 8 | word count below which the coach calls a prompt too vague |
+| `promptIdealMaxWords` | 200 | upper bound of the coach's "ideal length" band |
+| `promptTooLongWords` | 500 | word count above which the ask is considered buried |
+| `packBudgetPercent` | 25 | max share of the budget `/cco-pack` may consume |
+
+```bash
+/cco-config                          # table of all values, * = set by you
+/cco-config set rereadWarnAt 5       # fewer re-read warnings
+/cco-config set staleTimeMs 300000   # Read Cache re-allows after 5 min, not 10
+/cco-config reset staleTimeMs        # back to the default
+```
+
+`CCO_STALE_TIME_MS` in the environment still overrides `staleTimeMs`, for a
+one-off experiment without changing config.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,8 +21,10 @@ must make a number more true, a waste more visible, or a fix more automatic.
 
 ## v4.5 — Precision
 
+- [x] **Per-language token estimation** — shipped in v4.8.0: chars/line
+      measured over 6.3K real files, per extension, config-overridable (#35)
 - [ ] **Exact token counting** for estimates via a local BPE approximation
-      (self-calibration already narrows the gap; kill it entirely)
+      (self-calibration + per-language chars/line narrow the gap; kill it entirely)
 - [ ] **Per-model cache TTL awareness** (1h beta cache pricing) in economics
 - [ ] **Subagent economics**: split main-loop vs agent token spend in `/cco`
       and credit delegation savings to the advisor that suggested it

--- a/docs/index.html
+++ b/docs/index.html
@@ -836,7 +836,7 @@
   <div class="container">
     <div class="badge">
       <div class="badge-dot"></div>
-      v4.7.0 &middot; Claude 5 ready &middot; model auto-detect &middot; Benchmarked
+      v4.8.0 &middot; Claude 5 ready &middot; model auto-detect &middot; Benchmarked
     </div>
     <div class="hero-stat">63%</div>
     <h1>fewer tokens. <span class="highlight">Sharper prompts.</span><br>Works with every Claude.</h1>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.7.0",
-  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach — now Windows-correct",
+  "version": "4.8.0",
+  "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach, per-language token estimation, tunable thresholds via /cco-config",
   "type": "module",
   "main": "src/tracker.js",
   "bin": {

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -7,31 +7,48 @@
  *   - docs/index.html                 (footer "vX.Y.Z" badge)
  * Run before publish: npm run sync-version
  *
+ * With --check: writes nothing and exits 1 on any drift. CI runs this, because
+ * marketplace.json silently sat at 4.3.0 through the 4.5.0 and 4.6.0 releases —
+ * a stale version is invisible locally but ships to every marketplace user.
+ *
  * Also CHECKS (can't write — different repo) the external marketplace
  * egorfedorov/claude-plugins, which pins its own copy of the version and sat
- * two releases stale once. Warns on mismatch; best-effort on network failure.
+ * two releases stale once. Warns on mismatch; never fails the run, since it is
+ * served through a CDN that caches for minutes after a push.
  */
 
 import { readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
+const CHECK = process.argv.includes('--check');
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
 const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
 let changed = 0;
+const drift = [];
+
+/** Apply a fix, or record it as drift when running under --check. */
+function reconcile(label, before, write) {
+  if (CHECK) {
+    drift.push(`✗ ${label}: ${before} ≠ ${pkg.version}`);
+    return;
+  }
+  write();
+  console.log(`✓ ${label}: ${before} → ${pkg.version}`);
+  changed++;
+}
 
 // plugin.json
 const pluginPath = join(ROOT, '.claude-plugin', 'plugin.json');
 const plugin = JSON.parse(readFileSync(pluginPath, 'utf-8'));
 if (plugin.version !== pkg.version || plugin.description !== pkg.description) {
-  const before = plugin.version;
-  plugin.version = pkg.version;
-  plugin.description = pkg.description;
-  writeFileSync(pluginPath, JSON.stringify(plugin, null, 2) + '\n');
-  console.log(`✓ plugin.json: ${before} → ${pkg.version}`);
-  changed++;
+  reconcile('plugin.json', plugin.version, () => {
+    plugin.version = pkg.version;
+    plugin.description = pkg.description;
+    writeFileSync(pluginPath, JSON.stringify(plugin, null, 2) + '\n');
+  });
 }
 
 // marketplace.json
@@ -40,12 +57,11 @@ const market = JSON.parse(readFileSync(marketPath, 'utf-8'));
 for (const p of market.plugins || []) {
   if (p.name !== pkg.name) continue;
   if (p.version !== pkg.version || p.description !== pkg.description) {
-    const before = p.version;
-    p.version = pkg.version;
-    p.description = pkg.description;
-    writeFileSync(marketPath, JSON.stringify(market, null, 2) + '\n');
-    console.log(`✓ marketplace.json: ${before} → ${pkg.version}`);
-    changed++;
+    reconcile('marketplace.json', p.version, () => {
+      p.version = pkg.version;
+      p.description = pkg.description;
+      writeFileSync(marketPath, JSON.stringify(market, null, 2) + '\n');
+    });
   }
 }
 
@@ -54,12 +70,16 @@ const docsPath = join(ROOT, 'docs', 'index.html');
 const html = readFileSync(docsPath, 'utf-8');
 const synced = html.replace(/v\d+\.\d+\.\d+(?=\s*&middot;)/g, `v${pkg.version}`);
 if (synced !== html) {
-  writeFileSync(docsPath, synced);
-  console.log(`✓ docs/index.html → v${pkg.version}`);
-  changed++;
+  const before = (html.match(/v\d+\.\d+\.\d+(?=\s*&middot;)/) || ['?'])[0];
+  reconcile('docs/index.html', before, () => writeFileSync(docsPath, synced));
 }
 
-if (!changed) console.log(`✓ versions already in sync: ${pkg.version}`);
+if (CHECK && drift.length) {
+  console.error(`Version drift against package.json v${pkg.version}:\n  ${drift.join('\n  ')}`);
+  console.error('\nRun `npm run sync-version` and commit the result.');
+  process.exit(1);
+}
+if (!changed && !drift.length) console.log(`✓ versions already in sync: ${pkg.version}`);
 
 // External marketplace repo — read-only check, never fails the run.
 const EXT = 'egorfedorov/claude-plugins';
@@ -71,6 +91,7 @@ try {
   const ext = (await res.json()).plugins?.find(p => p.name === pkg.name);
   if (ext && ext.version !== pkg.version) {
     console.log(`⚠ ${EXT} still lists v${ext.version} — bump its .claude-plugin/marketplace.json to v${pkg.version}`);
+    console.log(`  (raw.githubusercontent is CDN-cached for a few minutes — verify with \`gh api\` before believing this)`);
   } else if (ext) {
     console.log(`✓ ${EXT} marketplace in sync: v${ext.version}`);
   }

--- a/skills/cco-config/SKILL.md
+++ b/skills/cco-config/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cco-config
+description: View and tune CCO's behavior thresholds — re-read warnings, cache staleness, prompt-coach length bands, and the /cco-pack budget cap
+license: MIT
+argument-hint: "[show | get <key> | set <key> <value> | reset [key]]"
+allowed-tools: [Bash]
+---
+
+# CCO Config — tune how aggressive the optimizer is
+
+CCO's behavior knobs used to be magic numbers spread across four modules.
+This surfaces them, range-validated, in `~/.claude-context-optimizer/config.json`
+under `thresholds`.
+
+The plugin root is the directory containing `src/config.js`. Run everything
+from there.
+
+Parse $ARGUMENTS:
+
+## `show` (or no arguments)
+
+```bash
+node src/config.js
+```
+
+Print the table as-is. `*` marks values the user set; `!` marks a stored value
+that failed validation and is being ignored in favour of the default. If any
+`!` rows appear, point them out — a typo there means a knob silently isn't
+doing what the user thinks.
+
+## `get <key>`
+
+```bash
+node src/config.js get <key>
+```
+
+## `set <key> <value>`
+
+```bash
+node src/config.js set <key> <value>
+```
+
+Exits non-zero with the valid range on a bad value or unknown key — relay that
+message rather than guessing a correction. After a successful set, say which
+behavior it changes (see the table below), because the effect is not obvious
+from the key name alone.
+
+## `reset [key]`
+
+```bash
+node src/config.js reset <key>    # one key
+node src/config.js reset          # everything back to defaults
+```
+
+Resetting everything discards all the user's tuning — confirm first unless they
+were explicit ("reset all", "вернуть всё по умолчанию").
+
+## The keys
+
+| Key | Default | What it changes |
+|---|---|---|
+| `rereadWarnAt` | 3 | reads of an unedited file before the first re-read warning |
+| `rereadEscalateAt` | 5 | reads before the "put it in CLAUDE.md" escalation |
+| `bigFileLines` | 500 | full-read line count that triggers the offset/limit warning |
+| `mediumFileLines` | 200 | full-read line count that triggers the soft hint |
+| `staleTokenRatio` | 0.10 | share of budget loaded after a file before Read Cache re-allows it |
+| `staleFiles` | 8 | other files loaded after a file before it counts as evicted (at 200K) |
+| `staleTimeMs` | 600000 | ms since last read before a cached file counts as stale |
+| `promptMinWords` | 8 | word count below which the coach calls a prompt too vague |
+| `promptIdealMaxWords` | 200 | upper bound of the coach's "ideal length" band |
+| `promptTooLongWords` | 500 | word count above which the ask is considered buried |
+| `packBudgetPercent` | 25 | max share of the budget `/cco-pack` may consume |
+
+## Tuning guidance
+
+- **Too many re-read warnings?** Raise `rereadWarnAt` to 4–5.
+- **Read Cache blocking files you still need?** Lower `staleTimeMs` (e.g.
+  `300000` = 5 min) or `staleTokenRatio` so cached entries go stale sooner.
+- **Read Cache not saving much?** Raise them — entries stay fresh longer and
+  more repeat reads get blocked.
+- **Working on a 1M-context model with long prompts?** Raise
+  `promptTooLongWords`; the default band is tuned for shorter asks.
+- `CCO_STALE_TIME_MS` in the environment still overrides `staleTimeMs`, for a
+  one-off experiment without changing config.

--- a/src/budget.js
+++ b/src/budget.js
@@ -101,8 +101,52 @@ function estimateToolTokens(toolName, toolInput) {
   }
 }
 
+// ── Pure decision cores (exported for tests) ─────────────────────────────────
+// The gating below decides what actually reaches Claude's context. It used to
+// live inline in main(), which reads stdin and calls process.exit — untestable.
+// These are pure: same inputs, same verdict, no I/O.
+
+/**
+ * Which budget thresholds are newly crossed at this usage level.
+ *
+ * Each threshold fires exactly once per session: `warningsSent` is the ledger
+ * of ones already emitted. Returns them ascending so a jump from 40% to 90%
+ * reports 50/70/85 in the order they were passed.
+ */
+export function selectWarnings(usagePercent, warnAt = [], warningsSent = []) {
+  return warnAt
+    .filter(t => usagePercent >= t && !warningsSent.includes(t))
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Did the prompt cache go cold during a pause worth warning about?
+ *
+ * The cache TTL is 5 minutes; re-warming re-bills the whole context at the
+ * cache-write rate. Below 20K of context the loss is pennies, so stay quiet.
+ */
+export function shouldWarnCacheBreak({ lastEventAt, realContextTokens, now, minGapMin = 5, minTokens = 20_000 }) {
+  if (!lastEventAt) return false;
+  if ((realContextTokens || 0) < minTokens) return false;
+  return (now - lastEventAt) / 60_000 >= minGapMin;
+}
+
+/**
+ * Has the session entered the quality-degradation zone?
+ *
+ * Only meaningful on 1M-window models: percentage warnings never fire early
+ * enough there, but quality drops around 300-400K. One-shot per session.
+ */
+export function shouldWarnContextRot({ contextWindow, contextTokens, alreadyWarned, threshold = 350_000 }) {
+  if (alreadyWarned) return false;
+  if (contextWindow < 1_000_000) return false;
+  return contextTokens >= threshold;
+}
+
 /**
  * Build a compact recommendation with specific files to drop.
+ * Exported at the bottom for tests — this is what turns "you're at 85%" into
+ * an action.
  */
 function buildCompactRecommendation(state) {
   const droppable = Object.entries(state.filesLoaded)
@@ -225,20 +269,22 @@ async function main() {
   // break that already happened, but naming its real cost teaches the habit:
   // batch pauses, /compact (or finish) before stepping away.
   const nowMs = Date.now();
-  if (state.lastEventAt && (state.realContextTokens || 0) >= 20_000) {
+  if (shouldWarnCacheBreak({
+    lastEventAt: state.lastEventAt,
+    realContextTokens: state.realContextTokens,
+    now: nowMs,
+  })) {
     const gapMin = (nowMs - state.lastEventAt) / 60_000;
-    if (gapMin >= 5) {
-      const rate = getModelCost(sessionModel).input / 1e6;
-      const lost = state.realContextTokens * rate * (CACHE_WRITE_MULT - CACHE_READ_MULT);
-      state.cacheBreaks = (state.cacheBreaks || 0) + 1;
-      emitNotice(sessionId, {
-        kind: `budget:cachebreak:${state.cacheBreaks}`,
-        text:
-          `[context-budget] ~${Math.round(gapMin)} min pause — the prompt cache (5-min TTL) went cold; ` +
-          `re-warming ${formatTokens(state.realContextTokens)} of context costs ~$${lost.toFixed(2)} extra. ` +
-          `Batch pauses: finish the task first, or /compact before a long break.`,
-      });
-    }
+    const rate = getModelCost(sessionModel).input / 1e6;
+    const lost = state.realContextTokens * rate * (CACHE_WRITE_MULT - CACHE_READ_MULT);
+    state.cacheBreaks = (state.cacheBreaks || 0) + 1;
+    emitNotice(sessionId, {
+      kind: `budget:cachebreak:${state.cacheBreaks}`,
+      text:
+        `[context-budget] ~${Math.round(gapMin)} min pause — the prompt cache (5-min TTL) went cold; ` +
+        `re-warming ${formatTokens(state.realContextTokens)} of context costs ~$${lost.toFixed(2)} extra. ` +
+        `Batch pauses: finish the task first, or /compact before a long break.`,
+    });
   }
   state.lastEventAt = nowMs;
   const contextNow = state.realContextTokens || state.totalTokensEstimated;
@@ -250,7 +296,11 @@ async function main() {
   // warnings (50/70/85) never fire that early on 1M, so this is a separate,
   // one-shot quality signal.
   const window = getModelCost(sessionModel).contextWindow;
-  if (window >= 1_000_000 && contextNow >= 350_000 && !state.rotWarned) {
+  if (shouldWarnContextRot({
+    contextWindow: window,
+    contextTokens: contextNow,
+    alreadyWarned: state.rotWarned,
+  })) {
     state.rotWarned = true;
     const rec = buildCompactRecommendation(state);
     emitNotice(sessionId, {
@@ -267,27 +317,25 @@ async function main() {
   // Only actionable signals reach Claude's context, and only a few per session.
   // 85%+ is critical (always shown, carries a /compact recommendation); the
   // early 50/70 nudges are 'normal' and may be suppressed once the cap is hit.
-  for (const threshold of config.warnAt) {
-    if (usagePercent >= threshold && !state.warningsSent.includes(threshold)) {
-      state.warningsSent.push(threshold);
+  for (const threshold of selectWarnings(usagePercent, config.warnAt, state.warningsSent)) {
+    state.warningsSent.push(threshold);
 
-      const cost = computeCost(state, sessionModel);
-      const src = state.realContextTokens ? '' : '~';
-      let msg = `[context-budget] ${usagePercent}% budget used (${src}${formatTokens(contextNow)}/${formatTokens(effectiveBudget)})`;
-      msg += ` | Cost: $${cost.toFixed(3)} (${sessionModel}: in ${formatTokens(state.inputTokensEstimated)} / out ${formatTokens(state.outputTokensEstimated)})`;
+    const cost = computeCost(state, sessionModel);
+    const src = state.realContextTokens ? '' : '~';
+    let msg = `[context-budget] ${usagePercent}% budget used (${src}${formatTokens(contextNow)}/${formatTokens(effectiveBudget)})`;
+    msg += ` | Cost: $${cost.toFixed(3)} (${sessionModel}: in ${formatTokens(state.inputTokensEstimated)} / out ${formatTokens(state.outputTokensEstimated)})`;
 
-      if (threshold >= 85) {
-        const rec = buildCompactRecommendation(state);
-        if (rec) msg += '\n' + rec.message;
-        else msg += ` | Consider /compact to free context`;
-      }
-
-      emitNotice(sessionId, {
-        kind: `budget:${threshold}`,
-        text: msg,
-        priority: threshold >= 85 ? 'critical' : 'normal',
-      });
+    if (threshold >= 85) {
+      const rec = buildCompactRecommendation(state);
+      if (rec) msg += '\n' + rec.message;
+      else msg += ` | Consider /compact to free context`;
     }
+
+    emitNotice(sessionId, {
+      kind: `budget:${threshold}`,
+      text: msg,
+      priority: threshold >= 85 ? 'critical' : 'normal',
+    });
   }
 
   // ── Auto-compact directives ──────────────────────────────────────────────

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+/**
+ * Config surface — /cco-config
+ *
+ * CCO's aggressiveness used to live as magic numbers across four modules:
+ * when a re-read is worth complaining about, when a cached file counts as
+ * evicted, what the prompt coach calls too short, how much budget /cco-pack
+ * may spend. Different context sizes and workflows want different answers,
+ * and tuning should never mean editing source.
+ *
+ * Usage:
+ *   node src/config.js                    # show all values + source
+ *   node src/config.js get <key>
+ *   node src/config.js set <key> <value>
+ *   node src/config.js reset [key]        # one key, or all when omitted
+ */
+
+import {
+  THRESHOLD_SPEC, DEFAULT_THRESHOLDS, validateThreshold, getThresholds,
+  clearThresholdCache, loadConfig, saveConfig, CONFIG_FILE,
+  isMainModule, getDonationMessage,
+} from './utils.js';
+
+// ── Pure core (exported for tests) ──────────────────────────────────────────
+
+/**
+ * Merge stored overrides onto defaults and label where each value came from.
+ * Invalid stored values are reported as such rather than silently applied —
+ * a typo must never make a hook behave wildly.
+ */
+export function describeThresholds(stored = {}) {
+  return Object.entries(THRESHOLD_SPEC).map(([key, [def, min, max, description]]) => {
+    const raw = stored[key];
+    if (raw === undefined) return { key, value: def, def, min, max, description, source: 'default' };
+    const r = validateThreshold(key, raw);
+    return r.ok
+      ? { key, value: r.value, def, min, max, description, source: 'config' }
+      : { key, value: def, def, min, max, description, source: 'invalid', error: r.error };
+  });
+}
+
+/** Apply one set operation. Returns { ok, thresholds, error }. */
+export function applySet(stored, key, rawValue) {
+  const r = validateThreshold(key, rawValue);
+  if (!r.ok) {
+    const known = Object.keys(THRESHOLD_SPEC).join(', ');
+    return { ok: false, error: `${r.error}\nKnown keys: ${known}` };
+  }
+  return { ok: true, thresholds: { ...stored, [key]: r.value } };
+}
+
+/** Remove one key, or all of them when key is omitted. */
+export function applyReset(stored, key) {
+  if (!key) return { ok: true, thresholds: {} };
+  if (!THRESHOLD_SPEC[key]) return { ok: false, error: `unknown key "${key}"` };
+  const next = { ...stored };
+  delete next[key];
+  return { ok: true, thresholds: next };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+function readStored() {
+  return loadConfig().thresholds || {};
+}
+
+function writeStored(thresholds) {
+  const cfg = loadConfig();
+  cfg.thresholds = thresholds;
+  saveConfig(cfg);
+  clearThresholdCache();
+}
+
+function show() {
+  const rows = describeThresholds(readStored());
+  const width = Math.max(...rows.map(r => r.key.length));
+
+  console.log('\n  CCO CONFIG — tunable thresholds');
+  console.log('  ' + '─'.repeat(72));
+  for (const r of rows) {
+    const mark = r.source === 'config' ? '*' : r.source === 'invalid' ? '!' : ' ';
+    const val = String(r.value).padEnd(9);
+    console.log(`  ${mark} ${r.key.padEnd(width)}  ${val}  ${r.description}`);
+    if (r.source === 'config') console.log(`  ${' '.repeat(width + 4)}(default ${r.def})`);
+    if (r.source === 'invalid') console.log(`  ${' '.repeat(width + 4)}IGNORED: ${r.error} — using ${r.def}`);
+  }
+  console.log('  ' + '─'.repeat(72));
+  console.log('  * = set by you   ! = invalid, ignored');
+  console.log(`  ${CONFIG_FILE}`);
+  console.log('\n  node src/config.js set <key> <value>   node src/config.js reset [key]\n');
+  const donation = getDonationMessage();
+  if (donation) console.log(donation);
+}
+
+function main() {
+  const [cmd, key, value] = process.argv.slice(2);
+
+  if (!cmd || cmd === 'show' || cmd === 'list') return show();
+
+  if (cmd === 'get') {
+    if (!key) { console.error('Usage: config.js get <key>'); process.exitCode = 1; return; }
+    const row = describeThresholds(readStored()).find(r => r.key === key);
+    if (!row) {
+      console.error(`Unknown key "${key}". Known: ${Object.keys(THRESHOLD_SPEC).join(', ')}`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`${row.key} = ${row.value}  (source: ${row.source}, default ${row.def}, range ${row.min}–${row.max})`);
+    return;
+  }
+
+  if (cmd === 'set') {
+    const before = getThresholds()[key];   // read BEFORE the write invalidates it
+    const r = applySet(readStored(), key, value);
+    if (!r.ok) { console.error(r.error); process.exitCode = 1; return; }
+    writeStored(r.thresholds);
+    const after = r.thresholds[key];
+    console.log(after === before
+      ? `✓ ${key} = ${after} (unchanged)`
+      : `✓ ${key} = ${after}  (was ${before})`);
+    return;
+  }
+
+  if (cmd === 'reset') {
+    const r = applyReset(readStored(), key);
+    if (!r.ok) { console.error(r.error); process.exitCode = 1; return; }
+    writeStored(r.thresholds);
+    console.log(key ? `✓ ${key} reset to ${DEFAULT_THRESHOLDS[key]}` : '✓ all thresholds reset to defaults');
+    return;
+  }
+
+  console.error(`Unknown command "${cmd}". Use: show | get <key> | set <key> <value> | reset [key]`);
+  process.exitCode = 1;
+}
+
+if (isMainModule(import.meta.url)) main();

--- a/src/prompt-coach.js
+++ b/src/prompt-coach.js
@@ -30,7 +30,7 @@ import { readFileSync, existsSync, appendFileSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import {
   PROMPTS_DIR, ensureDataDirs, loadJSON, saveJSON,
-  estimateTokensFromString, isQuietMode, isMainModule
+  estimateTokensFromString, isQuietMode, isMainModule, getThresholds
 } from './utils.js';
 
 ensureDataDirs();
@@ -182,6 +182,7 @@ export function analyzePrompt(prompt) {
   const trimmed = prompt.trim();
   const words = trimmed.split(/\s+/).filter(Boolean);
   const wordCount = words.length;
+  const PC = getThresholds();   // prompt* keys are user-tunable (#39)
 
   // ── Detect signals ──
   const filePathMatches = (trimmed.match(FILE_PATH_REGEX) || []).filter(s =>
@@ -209,7 +210,7 @@ export function analyzePrompt(prompt) {
     (hasUnbounded ? 0 : 50) +
     (hasStrongVerb ? 30 : 0) +
     (hasVagueVerb ? -20 : 0) +
-    (wordCount >= 8 && wordCount <= 200 ? 20 : 0)
+    (wordCount >= PC.promptMinWords && wordCount <= PC.promptIdealMaxWords ? 20 : 0)
   );
 
   const successCriteria = hasSuccess ? 100 :
@@ -217,7 +218,7 @@ export function analyzePrompt(prompt) {
 
   const lengthScore = wordCount < 4 ? 0 :
     wordCount < 10 ? 40 :
-    wordCount > 500 ? 50 :
+    wordCount > PC.promptTooLongWords ? 50 :
     100;
 
   // Weighted overall (specificity matters most for prompt quality)
@@ -255,7 +256,7 @@ export function analyzePrompt(prompt) {
   if (wordCount < 6) {
     suggestions.push('Prompt is very short — Claude will likely re-read many files to guess intent. Add 1–2 sentences of context.');
   }
-  if (wordCount > 500) {
+  if (wordCount > PC.promptTooLongWords) {
     suggestions.push('Prompt is long — the actual ask may be buried. Lead with one sentence stating the goal.');
   }
   if (hasQuestionMark && !hasStrongVerb && wordCount < 30) {

--- a/src/read-cache.js
+++ b/src/read-cache.js
@@ -31,7 +31,7 @@ import {
   READ_CACHE_DIR,
   estimateTokens, formatTokens, loadJSON, saveJSON, ensureDataDirs,
   loadConfig, getEffectiveBudget, isMainModule, getFileLines, shouldSkipFile,
-  getSessionModel
+  getSessionModel, getThresholds
 } from './utils.js';
 import { isContextIgnored } from './contextignore.js';
 import { parseFileStructure, formatDigest } from './file-digest.js';
@@ -47,9 +47,9 @@ ensureDataDirs();
 // values were 20K/8/10min) — the same fractions on 1M give ~100K/40/10min
 // which keeps Read Cache aggressive without false re-allows.
 
-const STALE_TOKEN_RATIO = 0.10;   // 10% of budget moved → other file likely evicted
-const STALE_FILES_FRACTION_BASE = 8;  // base value for 200K
-const STALE_TIME_MS_DEFAULT = 10 * 60 * 1000;
+// The base ratios are user-tunable (#39): config.thresholds.staleTokenRatio /
+// .staleFiles / .staleTimeMs, each range-validated. CCO_STALE_TIME_MS still
+// wins over config, for one-off experiments without editing anything.
 
 let _thresholdCache = null;
 let _sessionModel = null;
@@ -61,13 +61,14 @@ export function setSessionModel(rawModel) {
 function getStaleThresholds() {
   if (_thresholdCache) return _thresholdCache;
   const config = loadConfig();
+  const t = getThresholds();
   const budget = getEffectiveBudget(config, _sessionModel);
-  // Tokens: 10% of effective budget, clamped to [10K, 200K]
-  const tokens = Math.max(10_000, Math.min(200_000, Math.round(budget * STALE_TOKEN_RATIO)));
-  // Files: scale gently with budget (8 @ 200K, 32 @ 1M)
-  const files = Math.max(6, Math.min(40, Math.round(STALE_FILES_FRACTION_BASE * (budget / 200_000))));
-  // Time: respect env override
-  const timeMs = parseInt(process.env.CCO_STALE_TIME_MS || '', 10) || STALE_TIME_MS_DEFAULT;
+  // Tokens: share of effective budget, clamped to [10K, 200K]
+  const tokens = Math.max(10_000, Math.min(200_000, Math.round(budget * t.staleTokenRatio)));
+  // Files: scale gently with budget (8 @ 200K, 32 @ 1M by default)
+  const files = Math.max(6, Math.min(40, Math.round(t.staleFiles * (budget / 200_000))));
+  // Time: env override beats config
+  const timeMs = parseInt(process.env.CCO_STALE_TIME_MS || '', 10) || t.staleTimeMs;
   _thresholdCache = { tokens, files, timeMs, budget };
   return _thresholdCache;
 }
@@ -116,12 +117,15 @@ function isRangeCovered(ranges, offset, end) {
  *   2. Time decay: enough real time passed that context has likely shifted.
  *
  * Returns { stale: boolean, reason: string }.
+ *
+ * Pure given `thresholds` and `now` — both injectable so tests can drive the
+ * table without a real clock or a real config file. Production passes neither.
  */
-function checkStaleness(cache, filePath) {
+export function checkStaleness(cache, filePath, thresholds = null, now = null) {
   const entry = cache.files[filePath];
   if (!entry || !entry.readAtMs) return { stale: false, reason: '' };
 
-  const { tokens: tokTh, files: fileTh, timeMs } = getStaleThresholds();
+  const { tokens: tokTh, files: fileTh, timeMs } = thresholds || getStaleThresholds();
 
   const readTime = entry.readAtMs;
   let newerFiles = 0;
@@ -149,7 +153,7 @@ function checkStaleness(cache, filePath) {
     };
   }
 
-  const elapsed = Date.now() - readTime;
+  const elapsed = (now === null ? Date.now() : now) - readTime;
   if (elapsed >= timeMs) {
     const mins = Math.round(elapsed / 60_000);
     return {

--- a/src/smart-pack.js
+++ b/src/smart-pack.js
@@ -29,7 +29,7 @@ import { join, basename, extname, dirname } from 'path';
 import {
   PATTERNS_FILE, loadJSON, formatTokens, estimateTokens,
   computeUsefulness, computeConfidence, getEffectiveBudget, loadConfig,
-  shouldSkipFile
+  shouldSkipFile, getThresholds
 } from './utils.js';
 import { parseFileStructure } from './file-digest.js';
 
@@ -223,10 +223,11 @@ export function buildPack(task, cwd) {
 
   enriched.sort((a, b) => b.relevance - a.relevance);
 
-  // Honour budget — stop adding files once we'd consume >25% of effective budget.
+  // Honour budget — stop adding files once we'd consume more than
+  // thresholds.packBudgetPercent of the effective budget (default 25%, #39).
   const config = loadConfig();
   const budget = getEffectiveBudget(config);
-  const cap = Math.round(budget * 0.25);
+  const cap = Math.round(budget * (getThresholds().packBudgetPercent / 100));
   let running = 0;
   const final = [];
   for (const it of enriched) {

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -17,7 +17,7 @@ import {
   estimateTokens, formatTokens, displayPath, computeUsefulness, computeConfidence,
   getDonationMessage, loadJSON, saveJSON, ensureDataDirs,
   shouldIgnoreForTracking, getFileLines, getProjectRoot, isMainModule,
-  acquireFileLock
+  acquireFileLock, getThresholds
 } from './utils.js';
 import { emitNotice } from './notices.js';
 
@@ -155,14 +155,16 @@ function trackRead(session, filePath, lineCount, readOptions = {}) {
   // ── Real-time warnings ──
   const warnings = [];
 
-  if (file.reads >= 3 && !file.wasEdited) {
+  const TH = getThresholds();
+
+  if (file.reads >= TH.rereadWarnAt && !file.wasEdited) {
     const totalTokensSpent = file.estTokens * file.reads;
-    if (file.reads === 3) {
+    if (file.reads === TH.rereadWarnAt) {
       warnings.push(
         `[cco] ${basename(filePath)} read ${file.reads}x (~${formatTokens(totalTokensSpent)} tokens). ` +
         `Consider offset/limit for specific sections.`
       );
-    } else if (file.reads === 5) {
+    } else if (file.reads === TH.rereadEscalateAt) {
       warnings.push(
         `[cco] ${basename(filePath)} read ${file.reads}x (~${formatTokens(totalTokensSpent)} tokens). ` +
         `Add key parts to CLAUDE.md or memory to avoid re-reads.`
@@ -191,11 +193,11 @@ function trackRead(session, filePath, lineCount, readOptions = {}) {
     } catch { /* don't block on pattern load failure */ }
   }
 
-  if (!isPartial && lineCount > 500) {
+  if (!isPartial && lineCount > TH.bigFileLines) {
     warnings.push(
       `[cco] ${basename(filePath)} is ${lineCount} lines (~${formatTokens(tokens)} tokens). Use offset/limit to read specific sections.`
     );
-  } else if (!isPartial && lineCount > 200) {
+  } else if (!isPartial && lineCount > TH.mediumFileLines) {
     // Softer hint for medium files
     if (file.reads === 1) {
       warnings.push(
@@ -327,6 +329,57 @@ function prunePatterns(patterns) {
 
 // ── Session finalization ────────────────────────────────────────────────────
 
+/**
+ * Classify a session's files: what was useful, what was wasted, what got
+ * edited together. Pure — the surrounding finalizeSession() does the locking
+ * and the global read-modify-write, but this is the part that decides which
+ * tokens get reported as WASTE, which is the number the product is built on.
+ *
+ * A file is "wasted" when it was read at least once and scored no usefulness
+ * (read but never edited, never re-read for a reason). Its whole token cost
+ * counts, not a fraction — we paid for every read.
+ */
+export function aggregateSessionFiles(files) {
+  let sessionTokensTotal = 0;
+  let sessionTokensWasted = 0;
+  const perFile = {};
+  const editedFiles = [];
+
+  for (const [filePath, fileData] of Object.entries(files || {})) {
+    const tokensUsed = fileData.estTokens * fileData.reads;
+    sessionTokensTotal += tokensUsed;
+
+    const usefulness = computeUsefulness(fileData);
+    const isUseful = usefulness > 0;
+    const wasted = !isUseful && fileData.reads >= 1;
+    if (wasted) sessionTokensWasted += tokensUsed;
+
+    perFile[filePath] = { tokensUsed, usefulness, isUseful, wasted };
+    if (fileData.wasEdited) editedFiles.push(filePath);
+  }
+
+  return { sessionTokensTotal, sessionTokensWasted, perFile, editedFiles };
+}
+
+/**
+ * Symmetric co-occurrence counts for files edited in the same session.
+ * Pure. Bounded: a 1-file session has no pairs, and a >20-file session is a
+ * sweeping refactor whose pairs are noise, not signal — so it contributes none.
+ */
+export function buildCoOccurrence(editedFiles, into = {}) {
+  if (editedFiles.length < 2 || editedFiles.length > 20) return into;
+  for (let i = 0; i < editedFiles.length; i++) {
+    const a = editedFiles[i];
+    if (!into[a]) into[a] = {};
+    for (let j = 0; j < editedFiles.length; j++) {
+      if (i === j) continue;
+      const b = editedFiles[j];
+      into[a][b] = (into[a][b] || 0) + 1;
+    }
+  }
+  return into;
+}
+
 function finalizeSession(session) {
   const fileEntries = Object.entries(session.files);
   // Skip finalization for empty sessions
@@ -344,20 +397,13 @@ function finalizeSession(session) {
   const globalStats = loadGlobalStats();
   const proj = getProjectPatterns(patterns, session.projectRoot);
 
-  let sessionTokensTotal = 0;
-  let sessionTokensWasted = 0;
-  const editedFiles = [];
+  const { sessionTokensTotal, sessionTokensWasted, perFile, editedFiles } =
+    aggregateSessionFiles(session.files);
 
   for (const [filePath, fileData] of fileEntries) {
-    const tokensUsed = fileData.estTokens * fileData.reads;
-    sessionTokensTotal += tokensUsed;
+    const { tokensUsed, isUseful, wasted } = perFile[filePath];
 
-    const usefulness = computeUsefulness(fileData);
-    const isUseful = usefulness > 0;
-
-    if (!isUseful && fileData.reads >= 1) {
-      sessionTokensWasted += tokensUsed;
-
+    if (wasted) {
       if (!proj.wastedReads[filePath]) {
         proj.wastedReads[filePath] = { count: 0, sessions: 0, totalTokensWasted: 0 };
       }
@@ -378,24 +424,10 @@ function finalizeSession(session) {
     }
     // Update confidence score
     proj.fileFrequency[filePath].confidence = computeConfidence(proj.fileFrequency[filePath], 0);
-
-    if (fileData.wasEdited) {
-      editedFiles.push(filePath);
-    }
   }
 
-  // Build co-occurrence matrix
-  if (editedFiles.length >= 2 && editedFiles.length <= 20) {
-    for (let i = 0; i < editedFiles.length; i++) {
-      const a = editedFiles[i];
-      if (!proj.coOccurrence[a]) proj.coOccurrence[a] = {};
-      for (let j = 0; j < editedFiles.length; j++) {
-        if (i === j) continue;
-        const b = editedFiles[j];
-        proj.coOccurrence[a][b] = (proj.coOccurrence[a][b] || 0) + 1;
-      }
-    }
-  }
+  // Build co-occurrence matrix (editedFiles came from aggregateSessionFiles)
+  buildCoOccurrence(editedFiles, proj.coOccurrence);
 
   // Prune patterns to prevent unbounded growth
   prunePatterns(patterns);

--- a/src/utils.js
+++ b/src/utils.js
@@ -165,11 +165,65 @@ export const TOKEN_RATIOS = {
   '.svg': 3.0, '.proto': 3.6, '.graphql': 3.7, '.gql': 3.7, '.sql': 3.6,
 };
 
+// Average characters per LINE, by extension. Line count is what the hooks can
+// cheaply observe; chars/line is what turns it into a token estimate, so a flat
+// constant here biased the headline "tokens saved" figure per file.
+//
+// Values marked (m) were MEASURED over 6.3K real source files; the rest inherit
+// from the nearest measured sibling in the same family. Anything unlisted falls
+// back to AVG_CHARS_PER_LINE. Override any of these via config.charsPerLine.
+export const CHARS_PER_LINE = {
+  // Python family
+  '.py': 34.5, '.pyi': 35, '.pyx': 31, '.pxd': 22,                    // (m)
+  // JS / TS family
+  '.ts': 44, '.js': 39, '.mjs': 41,                                   // (m)
+  '.tsx': 40, '.jsx': 40, '.cjs': 39,
+  '.svelte': 42, '.vue': 42, '.astro': 42,                            // .svelte (m)
+  // Docs / markup
+  '.md': 36, '.txt': 28, '.html': 42, '.htm': 42,                     // (m)
+  '.mdx': 36, '.rst': 33, '.xml': 40,
+  // Data / config
+  '.json': 39, '.yml': 29, '.yaml': 29,                               // (m)
+  '.toml': 28, '.ini': 26, '.env': 26,
+  // Styles — notably SHORTER than the old flat 35
+  '.css': 25.3, '.scss': 26, '.sass': 24, '.less': 26, '.styl': 24,   // .css (m)
+  // Compiled / systems
+  '.go': 30, '.sql': 46, '.swift': 47, '.c': 40, '.h': 30,            // (m)
+  '.cpp': 40, '.cc': 40, '.cxx': 40, '.hpp': 30,
+  '.rs': 34, '.java': 40, '.kt': 38, '.cs': 38, '.scala': 38, '.dart': 38,
+  '.rb': 32, '.php': 38, '.lua': 32, '.pl': 34, '.r': 34,
+  // Shell
+  '.sh': 33.3, '.bash': 33, '.zsh': 33, '.fish': 33, '.ps1': 35,      // .sh (m)
+  // The big outlier: generated SVG runs ~3x the old flat assumption.
+  '.svg': 100.5,                                                       // (m)
+  '.proto': 32, '.graphql': 28, '.gql': 28,
+};
+
 const AVG_CHARS_PER_LINE = 35;
+
+let _charsPerLineOverrides = null;
+
+/**
+ * Chars-per-line for an extension: user override → measured default → 35.
+ * The config lookup is cached; hooks call this on every tracked file.
+ */
+export function charsPerLine(ext) {
+  if (_charsPerLineOverrides === null) {
+    const cfg = loadJSON(CONFIG_FILE);
+    _charsPerLineOverrides = (cfg && cfg.charsPerLine) || {};
+  }
+  const key = (ext || '').toLowerCase();
+  const override = _charsPerLineOverrides[key];
+  if (typeof override === 'number' && override > 0) return override;
+  return CHARS_PER_LINE[key] || AVG_CHARS_PER_LINE;
+}
+
+/** Test seam — drop the cached config overrides. */
+export function clearCharsPerLineCache() { _charsPerLineOverrides = null; }
 
 export function estimateTokens(lineCount, ext) {
   const ratio = TOKEN_RATIOS[ext] || 3.7;
-  return Math.round((lineCount * AVG_CHARS_PER_LINE) / ratio);
+  return Math.round((lineCount * charsPerLine(ext)) / ratio);
 }
 
 /** Estimate tokens directly from a string. Used by prompt-coach and budget. */
@@ -247,6 +301,69 @@ const DEFAULT_CONFIG = {
   bigFileDigest: true,         // on first full read of a very large file, show its
   bigFileThreshold: 1500,      // map once (≈14K+ tokens) so Claude reads targeted
 };
+
+// ── Tunable thresholds (#39) ─────────────────────────────────────────────────
+// These decide how aggressive CCO is. They were scattered as magic numbers
+// across four modules; different context sizes and workflows want different
+// aggressiveness, and tuning should not mean editing source.
+// Each entry: [default, min, max, description].
+export const THRESHOLD_SPEC = {
+  rereadWarnAt:       [3,      2,    20,      'reads of an unedited file before the first re-read warning'],
+  rereadEscalateAt:   [5,      3,    50,      'reads before the "put it in CLAUDE.md" escalation'],
+  bigFileLines:       [500,    100,  10000,   'full-read line count that triggers the offset/limit warning'],
+  mediumFileLines:    [200,    50,   5000,    'full-read line count that triggers the soft hint'],
+  staleTokenRatio:    [0.10,   0.01, 1,       'share of budget loaded after a file before it counts as evicted'],
+  staleFiles:         [8,      2,    100,     'other files loaded after a file before it counts as evicted (at 200K)'],
+  staleTimeMs:        [600000, 60000, 86400000, 'ms since last read before a cached file counts as stale'],
+  promptMinWords:     [8,      1,    100,     'prompt word count below which the coach calls it too vague'],
+  promptIdealMaxWords:[200,    20,   2000,    'upper bound of the coach\'s "ideal length" band'],
+  promptTooLongWords: [500,    50,   5000,    'prompt word count above which the ask is considered buried'],
+  packBudgetPercent:  [25,     1,    90,      'max share of the budget /cco-pack may consume'],
+};
+
+export const DEFAULT_THRESHOLDS = Object.fromEntries(
+  Object.entries(THRESHOLD_SPEC).map(([k, [d]]) => [k, d])
+);
+
+/**
+ * Validate a threshold value against its spec.
+ * Returns { ok, value, error } — callers decide whether to warn or throw.
+ */
+export function validateThreshold(key, raw) {
+  const spec = THRESHOLD_SPEC[key];
+  if (!spec) return { ok: false, error: `unknown key "${key}"` };
+  const [, min, max] = spec;
+  const value = typeof raw === 'string' ? Number(raw) : raw;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return { ok: false, error: `${key} must be a number` };
+  }
+  if (value < min || value > max) {
+    return { ok: false, error: `${key} must be between ${min} and ${max} (got ${value})` };
+  }
+  return { ok: true, value };
+}
+
+let _thresholds = null;
+
+/**
+ * Resolved thresholds: config.thresholds over defaults, invalid values
+ * ignored (a typo must never make a hook behave wildly). Cached — hooks call
+ * this on the hot path.
+ */
+export function getThresholds() {
+  if (_thresholds) return _thresholds;
+  const cfg = loadJSON(CONFIG_FILE);
+  const out = { ...DEFAULT_THRESHOLDS };
+  for (const [k, v] of Object.entries((cfg && cfg.thresholds) || {})) {
+    const r = validateThreshold(k, v);
+    if (r.ok) out[k] = r.value;
+  }
+  _thresholds = out;
+  return out;
+}
+
+/** Test seam — drop the cached thresholds. */
+export function clearThresholdCache() { _thresholds = null; }
 
 export function loadConfig() {
   const config = loadJSON(CONFIG_FILE);
@@ -495,7 +612,9 @@ export function getFileLines(filePath, maxBytes = 10 * 1024 * 1024) {
     // Hot path (called from Pre/PostToolUse hooks): don't slurp multi-MB files
     // just to count lines — estimate from size instead. Exact only when small.
     if (stat.size > 1024 * 1024) {
-      return Math.round(stat.size / (AVG_CHARS_PER_LINE + 1));
+      // +1 for the newline itself. Per-extension, so a 5MB .svg isn't counted
+      // as if its lines were 35 chars long when they average ~100.
+      return Math.round(stat.size / (charsPerLine(extname(filePath)) + 1));
     }
     const content = readFileSync(filePath, 'utf-8');
     return content.split('\n').length;

--- a/tests/test.js
+++ b/tests/test.js
@@ -10,10 +10,13 @@ import {
   BUDGET_CONFIG_FILE, loadJSON,
   MODEL_COSTS, MODEL_INPUT_COST, getModelCost, getModelContextWindow,
   getEffectiveBudget, categorizeFile, shouldSkipFile, shouldIgnoreForTracking,
-  isMainModule, getFileLines, toPosixPath
+  isMainModule, getFileLines, toPosixPath,
+  CHARS_PER_LINE, charsPerLine, clearCharsPerLineCache
 } from '../src/utils.js';
 import { analyzePrompt, buildImprovedPrompt, classifyPrompt } from '../src/prompt-coach.js';
 import { parseBaselineFromLines, projectTranscriptDir } from '../src/overhead.js';
+import { THRESHOLD_SPEC, validateThreshold } from '../src/utils.js';
+import { describeThresholds, applySet, applyReset } from '../src/config.js';
 import { buildIgnoreSuggestions } from '../src/context-shield.js';
 import { updateExploreStreak } from '../src/tracker.js';
 import { computeCacheAwareCost, emaCalibration } from '../src/utils.js';
@@ -23,15 +26,20 @@ import {
 import {
   emptyLedger, shouldEmit, recordEmit, DEFAULT_NOTICE_CAP
 } from '../src/notices.js';
-import { shouldNudgeBigFile } from '../src/read-cache.js';
-import { estimateToolTokens, computeCost } from '../src/budget.js';
+import { shouldNudgeBigFile, checkStaleness } from '../src/read-cache.js';
+import {
+  estimateToolTokens, computeCost, selectWarnings,
+  shouldWarnCacheBreak, shouldWarnContextRot, buildCompactRecommendation
+} from '../src/budget.js';
 import {
   isContextIgnored, _globToRegex, _parseIgnoreFile, clearContextIgnoreCache
 } from '../src/contextignore.js';
 import { writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs';
 import { parseUsageFromLines, readRealUsage, parseEconomicsFromLines } from '../src/transcript-usage.js';
 import { acquireFileLock } from '../src/utils.js';
-import { trackSearch, trackToolUse } from '../src/tracker.js';
+import {
+  trackSearch, trackToolUse, aggregateSessionFiles, buildCoOccurrence
+} from '../src/tracker.js';
 
 // ── Recreated pure functions from read-cache.js ─────────────────────────────
 
@@ -61,25 +69,65 @@ const shouldSkip = shouldSkipFile;
 
 describe('utils', () => {
   describe('estimateTokens', () => {
-    it('uses extension-specific ratio for .js', () => {
-      // 100 lines * 35 chars / 3.8 ratio = 921
-      assert.equal(estimateTokens(100, '.js'), Math.round((100 * 35) / 3.8));
+    it('uses extension-specific chars/line AND ratio for .js', () => {
+      assert.equal(estimateTokens(100, '.js'), Math.round((100 * CHARS_PER_LINE['.js']) / 3.8));
     });
 
-    it('uses extension-specific ratio for .md', () => {
-      assert.equal(estimateTokens(100, '.md'), Math.round((100 * 35) / 4.2));
+    it('uses extension-specific chars/line AND ratio for .md', () => {
+      assert.equal(estimateTokens(100, '.md'), Math.round((100 * CHARS_PER_LINE['.md']) / 4.2));
     });
 
-    it('uses extension-specific ratio for .json', () => {
-      assert.equal(estimateTokens(100, '.json'), Math.round((100 * 35) / 3.2));
+    it('uses extension-specific chars/line AND ratio for .json', () => {
+      assert.equal(estimateTokens(100, '.json'), Math.round((100 * CHARS_PER_LINE['.json']) / 3.2));
     });
 
-    it('falls back to 3.7 for unknown extensions', () => {
+    it('falls back to 3.7 ratio and 35 chars/line for unknown extensions', () => {
       assert.equal(estimateTokens(100, '.xyz'), Math.round((100 * 35) / 3.7));
     });
 
     it('returns 0 for 0 lines', () => {
       assert.equal(estimateTokens(0, '.js'), 0);
+    });
+  });
+
+  // #35: a flat 35 chars/line biased the headline "tokens saved" figure. These
+  // pin the per-extension behaviour against the measured sample.
+  describe('charsPerLine (#35)', () => {
+    it('reflects that SVG lines are ~3x longer than the old flat assumption', () => {
+      assert.ok(charsPerLine('.svg') > 90, 'measured ~100 chars/line');
+      // A 1000-line SVG was under-counted nearly 3x before.
+      assert.ok(estimateTokens(1000, '.svg') / Math.round((1000 * 35) / 3.0) > 2.5);
+    });
+
+    it('reflects that CSS lines are SHORTER than the old flat assumption', () => {
+      assert.ok(charsPerLine('.css') < 30, 'measured ~25 chars/line');
+      assert.ok(estimateTokens(1000, '.css') < Math.round((1000 * 35) / 3.8));
+    });
+
+    it('is case-insensitive about the extension', () => {
+      assert.equal(charsPerLine('.TS'), charsPerLine('.ts'));
+    });
+
+    it('falls back to 35 for an unlisted extension', () => {
+      assert.equal(charsPerLine('.zzz'), 35);
+      assert.equal(charsPerLine(''), 35);
+      assert.equal(charsPerLine(undefined), 35);
+    });
+
+    it('keeps every default within a sane 15-150 chars/line band', () => {
+      for (const [ext, v] of Object.entries(CHARS_PER_LINE)) {
+        assert.ok(v >= 15 && v <= 150, `${ext} = ${v} is out of band`);
+      }
+    });
+
+    it('lands within 25% of the measured value for the top languages', () => {
+      // Ground truth measured over 6.3K real files (see CHANGELOG 4.8.0).
+      const MEASURED = { '.py': 34.5, '.ts': 44, '.md': 35.8, '.json': 38.8, '.go': 29.9, '.css': 25.3 };
+      for (const [ext, real] of Object.entries(MEASURED)) {
+        const got = charsPerLine(ext);
+        assert.ok(Math.abs(got - real) / real < 0.25,
+          `${ext}: ${got} is >25% off the measured ${real}`);
+      }
     });
   });
 
@@ -1247,13 +1295,13 @@ describe('unified classification', () => {
 
 describe('estimateTokens (extended ratios)', () => {
   it('uses ratio for .svelte', () => {
-    assert.equal(estimateTokens(100, '.svelte'), Math.round((100 * 35) / 3.6));
+    assert.equal(estimateTokens(100, '.svelte'), Math.round((100 * CHARS_PER_LINE['.svelte']) / 3.6));
   });
   it('uses ratio for .sh', () => {
-    assert.equal(estimateTokens(100, '.sh'), Math.round((100 * 35) / 3.5));
+    assert.equal(estimateTokens(100, '.sh'), Math.round((100 * CHARS_PER_LINE['.sh']) / 3.5));
   });
   it('uses ratio for .php', () => {
-    assert.equal(estimateTokens(100, '.php'), Math.round((100 * 35) / 3.7));
+    assert.equal(estimateTokens(100, '.php'), Math.round((100 * CHARS_PER_LINE['.php']) / 3.7));
   });
 });
 
@@ -1416,8 +1464,10 @@ describe('cost + estimation regressions', () => {
 
   it('getFileLines estimates large files from size instead of reading them', () => {
     const tmp = join(homedir(), '.claude-context-optimizer', 'test-large.txt');
-    const line = 'x'.repeat(35) + '\n'; // matches the 36-bytes/line estimate
-    writeFileSync(tmp, line.repeat(40000)); // ~1.44MB, 40K lines
+    // Lines sized to .txt's measured chars/line, so the size-based shortcut
+    // should land on the real count. (#35 made this per-extension.)
+    const line = 'x'.repeat(charsPerLine('.txt')) + '\n';
+    writeFileSync(tmp, line.repeat(40000)); // 40K lines
     try {
       const lines = getFileLines(tmp);
       assert.ok(Math.abs(lines - 40000) < 2000, `estimate ${lines} too far from 40000`);
@@ -1771,5 +1821,342 @@ describe('MCP usage audit', () => {
     assert.equal(used[0].calls, 90);
     assert.deepEqual(unused.map(s => s.name), ['ghost']);
     assert.equal(unused[0].calls, 0);
+  });
+});
+
+// ── v4.8.0 (#36): the decision logic that actually gates output ─────────────
+// These paths decide what reaches Claude's context and which tokens get
+// reported as waste. Previously untested — the formatters had coverage, the
+// decisions did not.
+
+describe('budget: threshold gating', () => {
+  const WARN_AT = [50, 70, 85, 95];
+
+  it('emits a threshold exactly once per session', () => {
+    const sent = [];
+    // First crossing fires…
+    const first = selectWarnings(72, WARN_AT, sent);
+    assert.deepEqual(first, [50, 70]);
+    sent.push(...first);
+    // …a second event at the same level fires nothing.
+    assert.deepEqual(selectWarnings(72, WARN_AT, sent), []);
+    // …and only the newly crossed one fires later.
+    assert.deepEqual(selectWarnings(86, WARN_AT, sent), [85]);
+  });
+
+  it('reports skipped thresholds in ascending order on a big jump', () => {
+    assert.deepEqual(selectWarnings(96, WARN_AT, []), [50, 70, 85, 95]);
+  });
+
+  it('emits nothing below the lowest threshold', () => {
+    assert.deepEqual(selectWarnings(49, WARN_AT, []), []);
+  });
+
+  it('fires exactly at the boundary, not just above it', () => {
+    assert.deepEqual(selectWarnings(50, WARN_AT, []), [50]);
+  });
+
+  it('tolerates an empty/missing warnAt config', () => {
+    assert.deepEqual(selectWarnings(99, [], []), []);
+    assert.deepEqual(selectWarnings(99, undefined, undefined), []);
+  });
+});
+
+describe('budget: cache-break warning', () => {
+  const MIN = 60_000;
+  const base = { lastEventAt: 1_000_000, realContextTokens: 150_000 };
+
+  it('warns after a pause past the 5-min cache TTL', () => {
+    assert.equal(shouldWarnCacheBreak({ ...base, now: base.lastEventAt + 6 * MIN }), true);
+  });
+
+  it('stays quiet inside the TTL', () => {
+    assert.equal(shouldWarnCacheBreak({ ...base, now: base.lastEventAt + 4 * MIN }), false);
+  });
+
+  it('fires exactly at the 5-min boundary', () => {
+    assert.equal(shouldWarnCacheBreak({ ...base, now: base.lastEventAt + 5 * MIN }), true);
+  });
+
+  it('stays quiet when there is too little context to be worth re-warming', () => {
+    assert.equal(shouldWarnCacheBreak({
+      lastEventAt: base.lastEventAt, realContextTokens: 5_000, now: base.lastEventAt + 60 * MIN
+    }), false);
+  });
+
+  it('stays quiet on the first event of a session (no prior timestamp)', () => {
+    assert.equal(shouldWarnCacheBreak({
+      lastEventAt: null, realContextTokens: 500_000, now: 9_999_999
+    }), false);
+  });
+});
+
+describe('budget: context-rot warning', () => {
+  it('fires once past 350K on a 1M-window model', () => {
+    assert.equal(shouldWarnContextRot({
+      contextWindow: 1_000_000, contextTokens: 360_000, alreadyWarned: false
+    }), true);
+  });
+
+  it('never fires twice', () => {
+    assert.equal(shouldWarnContextRot({
+      contextWindow: 1_000_000, contextTokens: 900_000, alreadyWarned: true
+    }), false);
+  });
+
+  it('does not apply to 200K-window models (percent warnings cover those)', () => {
+    assert.equal(shouldWarnContextRot({
+      contextWindow: 200_000, contextTokens: 190_000, alreadyWarned: false
+    }), false);
+  });
+
+  it('stays quiet below the degradation zone', () => {
+    assert.equal(shouldWarnContextRot({
+      contextWindow: 1_000_000, contextTokens: 349_999, alreadyWarned: false
+    }), false);
+  });
+});
+
+describe('budget: compact recommendation', () => {
+  it('recommends dropping read-but-never-edited files, biggest first', () => {
+    const rec = buildCompactRecommendation({ filesLoaded: {
+      '/p/big.ts':    { reads: 2, edits: 0, tokens: 30_000 },
+      '/p/small.ts':  { reads: 1, edits: 0, tokens: 5_000 },
+      '/p/edited.ts': { reads: 3, edits: 2, tokens: 90_000 }, // in use — keep
+    }});
+    assert.deepEqual(rec.files, ['/p/big.ts', '/p/small.ts']);
+    assert.equal(rec.reclaimableTokens, 35_000);
+    assert.ok(!rec.message.includes('edited.ts'), 'must not suggest dropping an edited file');
+  });
+
+  it('returns null when every loaded file was edited', () => {
+    assert.equal(buildCompactRecommendation({ filesLoaded: {
+      '/p/a.ts': { reads: 1, edits: 1, tokens: 10_000 },
+    }}), null);
+  });
+
+  it('caps the suggestion list at 5 files', () => {
+    const filesLoaded = {};
+    for (let i = 0; i < 12; i++) filesLoaded[`/p/f${i}.ts`] = { reads: 1, edits: 0, tokens: 1000 * (i + 1) };
+    assert.equal(buildCompactRecommendation({ filesLoaded }).files.length, 5);
+  });
+});
+
+describe('read-cache: staleness', () => {
+  const TH = { tokens: 50_000, files: 8, timeMs: 10 * 60_000 };
+  const NOW = 5_000_000;
+  // A cache where `target` was read first, then `n` other files after it.
+  const cacheWith = (others) => ({ files: {
+    '/p/target.ts': { readAtMs: NOW - 60_000, tokens: 1000 },
+    ...Object.fromEntries(others.map((tokens, i) =>
+      [`/p/other${i}.ts`, { readAtMs: NOW - 30_000, tokens }])),
+  }});
+
+  it('is fresh when nothing displaced it', () => {
+    assert.equal(checkStaleness(cacheWith([]), '/p/target.ts', TH, NOW).stale, false);
+  });
+
+  it('goes stale once enough OTHER tokens were loaded after it', () => {
+    const r = checkStaleness(cacheWith([30_000, 25_000]), '/p/target.ts', TH, NOW);
+    assert.equal(r.stale, true);
+    assert.match(r.reason, /tokens of other files/);
+  });
+
+  it('goes stale on file count even when those files are tiny', () => {
+    const r = checkStaleness(cacheWith(Array(8).fill(10)), '/p/target.ts', TH, NOW);
+    assert.equal(r.stale, true);
+    assert.match(r.reason, /8 other files/);
+  });
+
+  it('goes stale on elapsed time alone', () => {
+    const cache = { files: { '/p/target.ts': { readAtMs: NOW - 11 * 60_000, tokens: 1000 } } };
+    const r = checkStaleness(cache, '/p/target.ts', TH, NOW);
+    assert.equal(r.stale, true);
+    assert.match(r.reason, /11 min since last read/);
+  });
+
+  it('ignores files read BEFORE the target (they cannot displace it)', () => {
+    const cache = { files: {
+      '/p/target.ts': { readAtMs: NOW - 60_000, tokens: 1000 },
+      '/p/older.ts':  { readAtMs: NOW - 120_000, tokens: 500_000 },
+    }};
+    assert.equal(checkStaleness(cache, '/p/target.ts', TH, NOW).stale, false);
+  });
+
+  it('is never stale for a file it has never seen', () => {
+    assert.equal(checkStaleness({ files: {} }, '/p/nope.ts', TH, NOW).stale, false);
+  });
+});
+
+describe('tracker: session aggregation', () => {
+  it('counts a read-once-never-edited file as pure waste', () => {
+    const r = aggregateSessionFiles({
+      '/p/waste.ts': { estTokens: 1000, reads: 1, edits: 0, wasEdited: false },
+    });
+    assert.equal(r.sessionTokensTotal, 1000);
+    assert.equal(r.sessionTokensWasted, 1000);
+    assert.equal(r.perFile['/p/waste.ts'].wasted, true);
+  });
+
+  it('treats a deliberate re-read as useful, not waste', () => {
+    // computeUsefulness credits re-reads (+0.5 each): coming back to a file is
+    // a signal it mattered, so it must not be billed as waste.
+    const r = aggregateSessionFiles({
+      '/p/reread.ts': { estTokens: 1000, reads: 2, edits: 0, wasEdited: false },
+    });
+    assert.equal(r.sessionTokensWasted, 0);
+    assert.equal(r.perFile['/p/reread.ts'].wasted, false);
+  });
+
+  it('charges ALL reads as waste when a big file is re-read but never edited', () => {
+    // The penalty path: 3+ reads of a >100-line file with no edit cancels the
+    // re-read credit — thrashing, not research. Every read was paid for.
+    const r = aggregateSessionFiles({
+      '/p/thrash.ts': { estTokens: 1000, reads: 3, edits: 0, wasEdited: false, lines: 500 },
+    });
+    assert.equal(r.sessionTokensTotal, 3000);
+    assert.equal(r.sessionTokensWasted, 3000, 'all 3 reads were paid for');
+    assert.equal(r.perFile['/p/thrash.ts'].wasted, true);
+  });
+
+  it('does not count an edited file as waste', () => {
+    const r = aggregateSessionFiles({
+      '/p/used.ts': { estTokens: 1000, reads: 2, edits: 1, wasEdited: true },
+    });
+    assert.equal(r.sessionTokensTotal, 2000);
+    assert.equal(r.sessionTokensWasted, 0);
+    assert.deepEqual(r.editedFiles, ['/p/used.ts']);
+  });
+
+  it('separates waste from useful work in a mixed session', () => {
+    const r = aggregateSessionFiles({
+      '/p/a.ts': { estTokens: 1000, reads: 2, edits: 1, wasEdited: true },  // 2000 useful
+      '/p/b.ts': { estTokens: 2000, reads: 1, edits: 0, wasEdited: false }, // 2000 wasted
+    });
+    assert.equal(r.sessionTokensTotal, 4000);
+    assert.equal(r.sessionTokensWasted, 2000);
+    assert.equal(Math.round((r.sessionTokensWasted / r.sessionTokensTotal) * 100), 50);
+  });
+
+  it('returns zeroes for an empty session', () => {
+    const r = aggregateSessionFiles({});
+    assert.equal(r.sessionTokensTotal, 0);
+    assert.equal(r.sessionTokensWasted, 0);
+    assert.deepEqual(r.editedFiles, []);
+  });
+
+  it('handles a missing files object without throwing', () => {
+    assert.equal(aggregateSessionFiles(undefined).sessionTokensTotal, 0);
+  });
+});
+
+describe('tracker: co-occurrence', () => {
+  it('links files edited together, symmetrically', () => {
+    const m = buildCoOccurrence(['/p/a.ts', '/p/b.ts']);
+    assert.equal(m['/p/a.ts']['/p/b.ts'], 1);
+    assert.equal(m['/p/b.ts']['/p/a.ts'], 1);
+  });
+
+  it('never links a file to itself', () => {
+    const m = buildCoOccurrence(['/p/a.ts', '/p/b.ts']);
+    assert.equal(m['/p/a.ts']['/p/a.ts'], undefined);
+  });
+
+  it('accumulates across sessions into the same matrix', () => {
+    const m = buildCoOccurrence(['/p/a.ts', '/p/b.ts']);
+    buildCoOccurrence(['/p/a.ts', '/p/b.ts'], m);
+    assert.equal(m['/p/a.ts']['/p/b.ts'], 2);
+  });
+
+  it('ignores a single-file session (no pair to learn)', () => {
+    assert.deepEqual(buildCoOccurrence(['/p/only.ts']), {});
+  });
+
+  it('ignores a sweeping >20-file refactor (pairs would be noise)', () => {
+    const many = Array.from({ length: 21 }, (_, i) => `/p/f${i}.ts`);
+    assert.deepEqual(buildCoOccurrence(many), {});
+  });
+});
+
+// ── v4.8.0 (#39): config surface ────────────────────────────────────────────
+
+describe('config: threshold validation', () => {
+  it('accepts a value inside the documented range', () => {
+    const r = validateThreshold('rereadWarnAt', 5);
+    assert.equal(r.ok, true);
+    assert.equal(r.value, 5);
+  });
+
+  it('coerces a numeric string (CLI args arrive as strings)', () => {
+    assert.deepEqual(validateThreshold('bigFileLines', '750'), { ok: true, value: 750 });
+  });
+
+  it('rejects out-of-range values with the range in the message', () => {
+    const r = validateThreshold('rereadWarnAt', 999);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /between 2 and 20/);
+  });
+
+  it('rejects an unknown key', () => {
+    assert.equal(validateThreshold('nope', 1).ok, false);
+  });
+
+  it('rejects non-numeric junk rather than coercing it to NaN', () => {
+    assert.equal(validateThreshold('bigFileLines', 'abc').ok, false);
+    assert.equal(validateThreshold('bigFileLines', null).ok, false);
+    assert.equal(validateThreshold('bigFileLines', {}).ok, false);
+  });
+
+  it('every default sits inside its own declared range', () => {
+    for (const [key, [def]] of Object.entries(THRESHOLD_SPEC)) {
+      assert.equal(validateThreshold(key, def).ok, true, `${key} default is out of its range`);
+    }
+  });
+});
+
+describe('config: describe/set/reset', () => {
+  it('labels untouched keys as defaults', () => {
+    const rows = describeThresholds({});
+    assert.ok(rows.every(r => r.source === 'default'));
+    assert.equal(rows.find(r => r.key === 'rereadWarnAt').value, 3);
+  });
+
+  it('labels overridden keys as config and uses the override', () => {
+    const row = describeThresholds({ rereadWarnAt: 7 }).find(r => r.key === 'rereadWarnAt');
+    assert.equal(row.source, 'config');
+    assert.equal(row.value, 7);
+  });
+
+  it('ignores an invalid stored value and falls back to the default', () => {
+    // A typo must never make a hook behave wildly.
+    const row = describeThresholds({ rereadWarnAt: 9999 }).find(r => r.key === 'rereadWarnAt');
+    assert.equal(row.source, 'invalid');
+    assert.equal(row.value, 3, 'must fall back to the default');
+    assert.match(row.error, /between/);
+  });
+
+  it('set refuses a bad value and lists the known keys', () => {
+    const r = applySet({}, 'rereadWarnAt', 999);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /Known keys:/);
+  });
+
+  it('set does not mutate the object it was given', () => {
+    const stored = { rereadWarnAt: 4 };
+    applySet(stored, 'bigFileLines', 900);
+    assert.deepEqual(stored, { rereadWarnAt: 4 });
+  });
+
+  it('reset with a key removes only that key', () => {
+    const r = applyReset({ rereadWarnAt: 4, bigFileLines: 900 }, 'rereadWarnAt');
+    assert.deepEqual(r.thresholds, { bigFileLines: 900 });
+  });
+
+  it('reset without a key clears everything', () => {
+    assert.deepEqual(applyReset({ rereadWarnAt: 4, bigFileLines: 900 }).thresholds, {});
+  });
+
+  it('reset rejects an unknown key instead of silently no-oping', () => {
+    assert.equal(applyReset({}, 'nope').ok, false);
   });
 });


### PR DESCRIPTION
Closes the remaining accuracy/coverage/config items from epic #41, plus a CI guard for the version drift found while shipping v4.7.0.

## Per-language token estimation (#35)

The headline **"tokens saved"** number was computed from a single constant — `AVG_CHARS_PER_LINE = 35`, applied to every file type. Chars-per-line is what converts an observed line count into a token estimate, so a flat value biased the central metric per file.

Rather than guess, I **measured 6,344 real source files**. The data contradicted the issue's own estimates:

| ext | measured | old flat | effect |
|---|---|---|---|
| `.svg` | **100.5** | 35 | under-counted ~3x |
| `.sql` | 46 | 35 | under-counted |
| `.ts` | 44 | 35 | under-counted |
| `.json` | 38.8 | 35 | issue guessed 18–22 — wrong |
| `.md` | 35.8 | 35 | issue guessed 45–60 — wrong |
| `.txt` | 27.8 | 35 | over-counted |
| `.css` | 25.3 | 35 | over-counted |

Also applied to the `getFileLines` size shortcut, so a 5MB SVG is no longer counted as if its lines were 35 chars. Overridable via `config.charsPerLine`.

This is **complementary to the existing self-calibration**, not redundant: the EMA factor corrects aggregate *session* drift and cannot fix per-*file* bias.

## Tunable thresholds + `/cco-config` (#39)

11 knobs hardcoded across four modules → `config.thresholds`, with `show | get | set | reset`. Every value is range-validated; an out-of-range or misspelled entry is **ignored in favour of the default and flagged with `!`**, never silently applied — a typo must not make a hook behave wildly. Documented in the README.

## Decision logic under test (#36)

The formatters had coverage; the code deciding what actually reaches Claude's context did not. Extracted the pure cores out of `main()` bodies that read stdin and call `process.exit`:

- **budget.js** — `selectWarnings` (fires once per threshold, ascending on a jump, boundary-inclusive), `shouldWarnCacheBreak`, `shouldWarnContextRot`, `buildCompactRecommendation`
- **read-cache.js** — `checkStaleness` exported with injectable clock + thresholds; table-driven over token/file/time displacement
- **tracker.js** — `aggregateSessionFiles`, `buildCoOccurrence`; `finalizeSession` now calls them instead of duplicating inline

Writing these caught that a **deliberate re-read scores as useful, not waste** — my first test asserted the opposite. Worth pinning, since it directly shapes the reported waste percentage.

## CI: version drift can't ship again

`marketplace.json` silently sat at 4.3.0 through the 4.5.0 and 4.6.0 releases. `sync-version.js --check` writes nothing and exits non-zero on any drift; CI runs it on every push and PR. Verified in both directions.

## Verification

- **238 tests pass**, up from 183. Node 18/20/22 + CodeQL.
- `/cco-config` round-trips end to end: `set` → `getThresholds()` reflects it → `reset` restores the default.
- All touched modules import cleanly; smoke-tested `overhead.js`, `dashboard.js`, `doctor.js`, `config.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)