### PR TITLE
ci: auto-merge Dependabot patch/minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+
+# CI-only version bumps used to sit in the PR queue for weeks (setup-node 6→7
+# waited three). Nothing about them needs a human: they touch a workflow file,
+# and the test matrix already proves whether they broke anything.
+#
+# Patch and minor bumps merge themselves once the required checks pass. MAJOR
+# bumps are left open on purpose — those can change runner behaviour in ways
+# green tests don't always catch, so they get a look.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # --auto queues the merge behind the branch protection checks rather than
+      # merging now, so a bump that breaks the matrix never lands.
+      - name: Enable auto-merge for patch and minor bumps
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Leave a note on major bumps
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "Major bump — not auto-merging. Check the action's changelog for runner or input changes, then merge by hand."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`setup-node` 6→7 sat open for three weeks. Nothing about a CI version bump needs a human — it touches a workflow file, and the test matrix already proves whether it broke anything.

## What this does

- **Patch and minor** Dependabot bumps enable `--auto`, which queues the merge *behind the required checks* rather than merging now. A bump that breaks the matrix never lands.
- **Major** bumps are left open on purpose, with a comment explaining why. Those can change runner behaviour in ways green tests don't always catch — `setup-node` 6→7 was exactly that kind, and it deserved the look it got.

## Repo settings changed alongside

- **Branch protection on `main`**: `test (18)`, `test (20)`, `test (22)` and `versions` are now required. Without required checks, `--auto` has nothing to wait for and merges instantly — which would have defeated the point.
- `enforce_admins: false`, so direct pushes to `main` still work for the owner.
- No required reviews (solo repo).
- Auto-merge enabled at the repo level.

CodeQL runs but is deliberately **not** required, so a slow or queued scan can't block a merge.

The workflow keeps the repo-wide default `GITHUB_TOKEN` permission at `read` and elevates only within this one workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)