### PR TITLE
fix(overhead): require observed MCP evidence before calling a server unused (#53)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-context-optimizer",
       "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach, per-language token estimation, tunable thresholds via /cco-config, self-learning tool costs, team pattern sharing",
-      "version": "4.9.0",
+      "version": "4.9.1",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach, per-language token estimation, tunable thresholds via /cco-config, self-learning tool costs, team pattern sharing",
   "author": {
     "name": "Egor Fedorov"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 4.9.1 — 2026-08-10
+
+### Fix: `/cco-overhead mcp` told fresh installs to delete working MCP servers (#53)
+
+On a fresh install the audit reported **every** configured MCP server as
+`0 calls` and printed a ready-to-run `claude mcp remove` for each — including
+servers in active, heavy use. The skill then offered to execute them.
+
+The cold-start guard existed but asked the wrong question: it counted session
+*files* (`sessions >= 5`), not whether a single `mcp__*` call had ever been
+observed. A handful of short sessions cleared the bar while carrying zero MCP
+evidence, so a tracker that had been running for twenty minutes rendered a
+confident "last 30 days" verdict.
+
+- New `haveMcpEvidence(usage, sessions)`: a server may be judged unused only
+  when the tracker has recorded **at least one MCP call somewhere**. Zero
+  observed calls is absence of evidence, not evidence of absence.
+- Unobserved servers now render `? not observed — no data yet, not a verdict`
+  instead of `✖ 0 calls`, and **no removal command is printed at all**.
+- The header states the **real observed span** ("last 3 day(s) observed")
+  instead of a fixed "last 30 days" the data may not cover.
+- `cco-overhead` skill: never suggest removing a `? not observed` server, and
+  never construct a `claude mcp remove` the report did not print.
+
+The asymmetry is the point — a genuinely unused server and one the tracker
+never watched look identical in the data, and only one is safe to remove.
+Failing closed costs the user nothing; failing open costs working config.
+
+### Docs
+- README: Awesome Claude Code badge (#54).
+
 ## 4.9.0 — 2026-08-05
 
 ### Self-learning tool costs (#38)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
   <img src="https://img.shields.io/badge/telemetry-none-critical?style=flat-square" alt="No Telemetry"/>
 </p>
 
+<p align="center">
+  <a href="https://github.com/hesreallyhim/awesome-claude-code"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Claude Code"/></a>
+</p>
+
 ---
 
 ## The Problem

--- a/docs/index.html
+++ b/docs/index.html
@@ -836,7 +836,7 @@
   <div class="container">
     <div class="badge">
       <div class="badge-dot"></div>
-      v4.9.0 &middot; Claude 5 ready &middot; model auto-detect &middot; Benchmarked
+      v4.9.1 &middot; Claude 5 ready &middot; model auto-detect &middot; Benchmarked
     </div>
     <div class="hero-stat">63%</div>
     <h1>fewer tokens. <span class="highlight">Sharper prompts.</span><br>Works with every Claude.</h1>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-context-optimizer",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Opus 4.8-aware context optimization: cache-aware real costs & cache-break detection, session baseline audit (/cco-overhead), auto .contextignore, self-calibrating estimates, delegation advisor, ru/en prompt coach, per-language token estimation, tunable thresholds via /cco-config, self-learning tool costs, team pattern sharing",
   "type": "module",
   "main": "src/tracker.js",

--- a/skills/cco-overhead/SKILL.md
+++ b/skills/cco-overhead/SKILL.md
@@ -37,9 +37,13 @@ called:
 node ${CLAUDE_PLUGIN_ROOT}/src/overhead.js mcp
 ```
 
-If it lists unused servers with `claude mcp remove ...` commands, OFFER to run
-them for the user (each removal repays in every future session; `claude mcp
+Only if the report actually prints `claude mcp remove ...` commands, OFFER to
+run them for the user (each removal repays in every future session; `claude mcp
 add` restores any time). Only run them after the user agrees.
+
+If a server is listed as `? not observed`, the tracker has no MCP data yet —
+that is not a verdict. Never suggest removing those servers, and never
+construct a `claude mcp remove` command the report did not print.
 
 Present the output to the user as-is (it is already formatted). If the report
 says no transcripts were found, explain that the audit needs at least one

--- a/src/overhead.js
+++ b/src/overhead.js
@@ -236,14 +236,16 @@ export function collectConfiguredMcpServers(cwd, home = homedir()) {
 /** Sum mcp__<server>__* calls across tracked sessions newer than sinceMs. */
 export function aggregateMcpUsage(sessionsDir = SESSIONS_DIR, sinceMs = Date.now() - 30 * 86400_000) {
   const usage = {};
-  let sessions = 0;
+  let sessions = 0, oldestMs = 0;
   try {
     for (const f of readdirSync(sessionsDir).filter(f => f.endsWith('.json'))) {
       const p = join(sessionsDir, f);
       try {
-        if (statSync(p).mtimeMs < sinceMs) continue;
+        const mtimeMs = statSync(p).mtimeMs;
+        if (mtimeMs < sinceMs) continue;
         const s = JSON.parse(readFileSync(p, 'utf-8'));
         sessions++;
+        if (!oldestMs || mtimeMs < oldestMs) oldestMs = mtimeMs;
         for (const [tool, d] of Object.entries(s.tools || {})) {
           if (!tool.startsWith('mcp__')) continue;
           const server = tool.split('__')[1] || '';
@@ -252,7 +254,7 @@ export function aggregateMcpUsage(sessionsDir = SESSIONS_DIR, sinceMs = Date.now
       } catch { /* skip unreadable session */ }
     }
   } catch { /* no sessions dir */ }
-  return { usage, sessions };
+  return { usage, sessions, oldestMs };
 }
 
 /** Split configured servers into used/unused given observed calls. Pure. */
@@ -266,14 +268,25 @@ export function splitMcpByUsage(configured, usage) {
   return { used, unused };
 }
 
-export function buildMcpReport(cwd) {
+/**
+ * Can a configured-but-unobserved server honestly be called "unused"? Pure.
+ * Zero observed MCP calls anywhere means the tracker has no MCP data — absence
+ * of evidence, not evidence of absence — so no server may be judged unused.
+ */
+export function haveMcpEvidence(usage, sessions) {
+  const totalCalls = Object.values(usage).reduce((a, b) => a + b, 0);
+  return sessions >= 5 && totalCalls > 0;
+}
+
+export function buildMcpReport(cwd, now = Date.now()) {
   const configured = collectConfiguredMcpServers(cwd);
-  const { usage, sessions } = aggregateMcpUsage();
+  const { usage, sessions, oldestMs } = aggregateMcpUsage();
   const { used, unused } = splitMcpByUsage(configured, usage);
+  const observedDays = oldestMs ? Math.max(1, Math.round((now - oldestMs) / 86400_000)) : 0;
 
   const L = [];
   L.push('');
-  L.push('  MCP SERVER USAGE — last 30 days');
+  L.push(`  MCP SERVER USAGE — ${observedDays ? `last ${observedDays} day(s) observed` : 'no tracked sessions yet'}`);
   L.push('  ' + '─'.repeat(60));
   if (!configured.length) {
     L.push('  No MCP servers configured (checked ~/.claude.json and ./.mcp.json).');
@@ -284,10 +297,13 @@ export function buildMcpReport(cwd) {
   for (const s of used) {
     L.push(`    ✔ ${s.name.padEnd(28)} ${String(s.calls).padStart(6)} calls   (${s.scope})`);
   }
+  const evidence = haveMcpEvidence(usage, sessions);
   for (const s of unused) {
-    L.push(`    ✖ ${s.name.padEnd(28)}      0 calls   (${s.scope}) — schemas still load every session`);
+    L.push(evidence
+      ? `    ✖ ${s.name.padEnd(28)}      0 calls   (${s.scope}) — schemas still load every session`
+      : `    ? ${s.name.padEnd(28)}   not observed  (${s.scope}) — no data yet, not a verdict`);
   }
-  if (unused.length && sessions >= 5) {
+  if (unused.length && evidence) {
     L.push('');
     L.push('  Fix — remove what you never call (each removal repays in EVERY session):');
     for (const s of unused) {
@@ -296,7 +312,10 @@ export function buildMcpReport(cwd) {
     L.push('  (re-add any time with `claude mcp add`)');
   } else if (unused.length) {
     L.push('');
-    L.push(`  Only ${sessions} tracked session(s) so far — verdicts firm up at 5+. Re-run later.`);
+    L.push(Object.values(usage).reduce((a, b) => a + b, 0) === 0
+      ? '  No MCP calls observed yet — tracking usually started recently. Verdicts appear'
+        + '\n  once CCO has seen MCP activity; nothing here is a reason to remove a server.'
+      : `  Only ${sessions} tracked session(s) so far — verdicts firm up at 5+. Re-run later.`);
   } else {
     L.push('');
     L.push('  ✅ Every configured server was actually used. Nothing to trim.');

--- a/src/overhead.js
+++ b/src/overhead.js
@@ -19,7 +19,7 @@
  *   node src/overhead.js                      # last 10 sessions of this project
  */
 
-import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { readFileSync, readdirSync, existsSync, statSync, openSync, fstatSync, closeSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import {
@@ -240,10 +240,14 @@ export function aggregateMcpUsage(sessionsDir = SESSIONS_DIR, sinceMs = Date.now
   try {
     for (const f of readdirSync(sessionsDir).filter(f => f.endsWith('.json'))) {
       const p = join(sessionsDir, f);
+      // stat and read through ONE handle: the recency check and the read must
+      // describe the same file, or a session rotated mid-scan skews the window.
+      let fd;
       try {
-        const mtimeMs = statSync(p).mtimeMs;
+        fd = openSync(p, 'r');
+        const mtimeMs = fstatSync(fd).mtimeMs;
         if (mtimeMs < sinceMs) continue;
-        const s = JSON.parse(readFileSync(p, 'utf-8'));
+        const s = JSON.parse(readFileSync(fd, 'utf-8'));
         sessions++;
         if (!oldestMs || mtimeMs < oldestMs) oldestMs = mtimeMs;
         for (const [tool, d] of Object.entries(s.tools || {})) {
@@ -252,6 +256,7 @@ export function aggregateMcpUsage(sessionsDir = SESSIONS_DIR, sinceMs = Date.now
           if (server) usage[server] = (usage[server] || 0) + (d.calls || 0);
         }
       } catch { /* skip unreadable session */ }
+      finally { if (fd !== undefined) try { closeSync(fd); } catch { /* already gone */ } }
     }
   } catch { /* no sessions dir */ }
   return { usage, sessions, oldestMs };

--- a/tests/test.js
+++ b/tests/test.js
@@ -1828,6 +1828,15 @@ describe('MCP usage audit', () => {
     assert.deepEqual(unused.map(s => s.name), ['ghost']);
     assert.equal(unused[0].calls, 0);
   });
+
+  // #53: a tracker that never saw an MCP call must not sentence servers to removal.
+  it('withholds unused verdicts until an MCP call was actually observed', async () => {
+    const { haveMcpEvidence } = await import('../src/overhead.js');
+    assert.equal(haveMcpEvidence({}, 25), false);          // many sessions, zero MCP data
+    assert.equal(haveMcpEvidence({ ghost: 0 }, 25), false); // key present, still no calls
+    assert.equal(haveMcpEvidence({ chrome: 2 }, 3), false); // real calls, too few sessions
+    assert.equal(haveMcpEvidence({ chrome: 2 }, 5), true);  // evidence + enough sessions
+  });
 });
 
 // ── v4.8.0 (#36): the decision logic that actually gates output ─────────────


### PR DESCRIPTION
Closes #53. Closes #54.

## #53 — the audit told fresh installs to delete working MCP servers

`/cco-overhead mcp` reported **every** configured MCP server as `0 calls` and printed a ready-to-run `claude mcp remove` for each — including servers in active, heavy use. The `cco-overhead` skill then offers to execute those commands, so the failure mode was a confident, executable recommendation to delete working configuration.

The cold-start guard existed but asked the wrong question:

```js
if (unused.length && sessions >= 5) { /* print `claude mcp remove ...` */ }
```

`sessions` counted session *files*, regardless of whether any contained tool records. Seven near-empty sessions satisfy `>= 5` while carrying zero evidence about MCP usage — so a tracker that had existed for twenty minutes rendered a "last 30 days" verdict.

### Fix

- **`haveMcpEvidence(usage, sessions)`** — a server may be judged unused only when the tracker recorded at least one `mcp__*` call *somewhere*. Zero observed calls across every tracked session means the tracker has no MCP data, not that no server was called.
- Unobserved servers render `? not observed — no data yet, not a verdict` instead of `✖ 0 calls`, and **no removal command is printed**.
- The header states the real observed span (`last 3 day(s) observed`) instead of a fixed `last 30 days` the data may not cover.
- Skill updated: never suggest removing a `? not observed` server, never construct a `claude mcp remove` the report did not print.

The asymmetry generalises — a genuinely unused server and one the tracker never watched are indistinguishable in the data, and only one is safe to remove. Failing closed costs the user nothing; failing open costs them working config.

### Verification

Reproduced the reporter's exact setup (1 configured server, 7 sessions with no MCP records):

```
  MCP SERVER USAGE — last 1 day(s) observed
  1 server(s) configured · evidence from 7 tracked session(s)

    ? codegraph                      not observed  (user) — no data yet, not a verdict

  No MCP calls observed yet — tracking usually started recently. Verdicts appear
  once CCO has seen MCP activity; nothing here is a reason to remove a server.
```

And confirmed the genuine-unused path is unchanged (same 7 sessions, now containing real `mcp__codegraph__*` calls, plus a configured-but-uncalled `ghost`):

```
    ✔ codegraph                        28 calls   (user)
    ✖ ghost                             0 calls   (user) — schemas still load every session

  Fix — remove what you never call (each removal repays in EVERY session):
    claude mcp remove "ghost" -s user
```

New test covers the four corners of the gate (no data / key-with-zero / too-few-sessions / real evidence). 275 tests pass.

## #54 — Awesome Claude Code badge

Added to the README badge block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)