### PR TITLE
fix(sync-version): read the external marketplace through the API, not the CDN

### DIFF
--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -83,15 +83,30 @@ if (!changed && !drift.length) console.log(`✓ versions already in sync: ${pkg.
 
 // External marketplace repo — read-only check, never fails the run.
 const EXT = 'egorfedorov/claude-plugins';
+// Read through the API, NOT raw.githubusercontent: the raw CDN kept serving a
+// stale `x-cache: HIT` to fetch() long after the bump landed — through
+// cache-busting query strings and no-cache headers alike — so the check
+// reported a bump it had just been told to make. The API reflects the commit
+// immediately. Falls back to raw (with the caveat) if the API is unreachable.
+async function fetchExtVersion() {
+  const opts = { signal: AbortSignal.timeout(4000), headers: { 'User-Agent': 'cco-sync-version' } };
+  try {
+    const res = await fetch(`https://api.github.com/repos/${EXT}/contents/.claude-plugin/marketplace.json`,
+      { ...opts, headers: { ...opts.headers, Accept: 'application/vnd.github.raw' } });
+    if (!res.ok) throw new Error(`api ${res.status}`);
+    return { data: JSON.parse(await res.text()), stale: false };
+  } catch {
+    const res = await fetch(`https://raw.githubusercontent.com/${EXT}/main/.claude-plugin/marketplace.json`, opts);
+    return { data: await res.json(), stale: true };
+  }
+}
+
 try {
-  const res = await fetch(
-    `https://raw.githubusercontent.com/${EXT}/main/.claude-plugin/marketplace.json`,
-    { signal: AbortSignal.timeout(4000) }
-  );
-  const ext = (await res.json()).plugins?.find(p => p.name === pkg.name);
+  const { data, stale } = await fetchExtVersion();
+  const ext = data.plugins?.find(p => p.name === pkg.name);
   if (ext && ext.version !== pkg.version) {
     console.log(`⚠ ${EXT} still lists v${ext.version} — bump its .claude-plugin/marketplace.json to v${pkg.version}`);
-    console.log(`  (raw.githubusercontent is CDN-cached for a few minutes — verify with \`gh api\` before believing this)`);
+    if (stale) console.log('  (read via the CDN, which can serve a stale copy — confirm with `gh api` before believing it)');
   } else if (ext) {
     console.log(`✓ ${EXT} marketplace in sync: v${ext.version}`);
   }


### PR DESCRIPTION
Found while cutting v4.9.1.

After bumping `egorfedorov/claude-plugins` to 4.9.1 and confirming it landed, `npm run sync-version` still insisted:

```
⚠ egorfedorov/claude-plugins still lists v4.9.0 — bump its .claude-plugin/marketplace.json to v4.9.1
  (raw.githubusercontent is CDN-cached for a few minutes — verify with `gh api` before believing this)
```

This is not the few-minutes lag the comment assumes. `curl` saw 4.9.1 while `fetch()` kept getting a stale `x-cache: HIT` — and it survived both a cache-busting query string and `Cache-Control: no-cache`:

```
plain      4.9.0 | cache: HIT
no-cache   4.9.0 | cache: HIT
bust       4.9.0 | cache: HIT
```

The API contents endpoint returned 4.9.1 immediately from the same process.

So the check was unreliable in the one direction that matters — it cries wolf on a marketplace that is already correct, which is exactly how a real stale-marketplace warning gets ignored. (The script's docblock notes marketplace.json "silently sat at 4.3.0 through the 4.5.0 and 4.6.0 releases" — this check exists to prevent that, so it needs to be believable.)

### Change

Read `api.github.com/repos/.../contents/...` with `Accept: application/vnd.github.raw`, which reflects the commit immediately. Fall back to the CDN if the API is unreachable (rate limit, offline), keeping the staleness caveat *only* on that path where it's actually true. Still never fails the run.

### Verification

```
$ node scripts/sync-version.js
✓ versions already in sync: 4.9.1
✓ egorfedorov/claude-plugins marketplace in sync: v4.9.1

$ # with api.github.com forced to fail — fallback path
⚠ egorfedorov/claude-plugins still lists v4.9.0 — bump its ...
  (read via the CDN, which can serve a stale copy — confirm with `gh api` before believing it)
```

The fallback output doubles as proof the original bug was real: the CDN was still serving 4.9.0 at that moment.

`scripts/` is not in package.json `files`, so this ships to no user and needs no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)