### PR TITLE
docs(changelog): credit @harvest316 for the #53 report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fix: `/cco-overhead mcp` told fresh installs to delete working MCP servers (#53)
 
+Reported by [@harvest316](https://github.com/harvest316), with the root cause,
+the on-disk verification, and the fix already in the report.
+
 On a fresh install the audit reported **every** configured MCP server as
 `0 calls` and printed a ready-to-run `claude mcp remove` for each — including
 servers in active, heavy use. The skill then offered to execute them.


### PR DESCRIPTION
The v4.9.1 CHANGELOG entry and release notes described the #53 fix without naming who found it. [@harvest316](https://github.com/harvest316)'s report contained the root cause, the on-disk verification and the suggested fix — the code change was the small part.

Issue reporters never land in GitHub's Contributors graph (it is commit-based), so the CHANGELOG and release notes are where that credit has to live. Release notes already updated in place; this brings the CHANGELOG in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)