### PR TITLE
fix(smart-pack): scope historic candidates to the project, and test the logic

### DIFF
--- a/src/smart-pack.js
+++ b/src/smart-pack.js
@@ -29,7 +29,7 @@ import { join, basename, extname, dirname } from 'path';
 import {
   PATTERNS_FILE, loadJSON, formatTokens, estimateTokens,
   computeUsefulness, computeConfidence, getEffectiveBudget, loadConfig,
-  shouldSkipFile, getThresholds
+  shouldSkipFile, getThresholds, toPosixPath
 } from './utils.js';
 import { parseFileStructure } from './file-digest.js';
 
@@ -73,8 +73,29 @@ function extractMentionedPaths(task, cwd) {
   return [...new Set(real)];
 }
 
+// ── Path scoping ─────────────────────────────────────────────────────────────
+
+/** Is `filePath` at or below `root`? Boundary-aware: /a/bc is NOT inside /a/b. */
+export function isInside(filePath, root) {
+  if (!filePath || !root) return false;
+  const p = toPosixPath(filePath);
+  const r = toPosixPath(root).replace(/\/+$/, '');
+  return p === r || p.startsWith(r + '/');
+}
+
+/**
+ * The recorded project root that owns `cwd` — the longest tracked key `cwd`
+ * sits inside, else `cwd` itself. Files outside this scope belong to another
+ * project and must never be proposed as context for this one.
+ */
+export function projectScope(cwd, projectKeys = []) {
+  return projectKeys
+    .filter(k => k !== '_global' && isInside(cwd, k))
+    .sort((a, b) => b.length - a.length)[0] || cwd;
+}
+
 /** Extract keywords for grep-like matching against file paths. */
-function extractKeywords(task) {
+export function extractKeywords(task) {
   if (!task) return [];
   return task
     .toLowerCase()
@@ -109,11 +130,16 @@ function findFilesByKeywords(cwd, keywords, limit = 12) {
 
 function findHistoricallyUseful(cwd, limit = 8) {
   const patterns = loadJSON(PATTERNS_FILE) || { projects: {} };
+  const scope = projectScope(cwd, Object.keys(patterns.projects || {}));
   const candidates = [];
   for (const [projKey, proj] of Object.entries(patterns.projects || {})) {
-    if (projKey !== '_global' && !cwd.startsWith(projKey)) continue;
+    if (projKey !== '_global' && !isInside(cwd, projKey)) continue;
     for (const [path, data] of Object.entries(proj.fileFrequency || {})) {
       if (data.usefulness < 2 || (data.totalEdits || 0) === 0) continue;
+      // The _global bucket spans every project on this machine, and a file from
+      // another repo exists on disk — so it clears every other filter and gets
+      // proposed as context for THIS project. Scope is the only thing stopping it.
+      if (!isInside(path, scope)) continue;
       const daysSince = data.lastSeen
         ? Math.round((Date.now() - new Date(data.lastSeen)) / 86400000)
         : 30;
@@ -171,6 +197,55 @@ function suggestRange(filePath, keywords) {
   }
 }
 
+// ── Pure decision logic ──────────────────────────────────────────────────────
+
+/**
+ * Merge the four candidate sources into one ranked list.
+ * Priority is by source: mentioned > changed > historic > keyword — the first
+ * source to claim a path owns it, so a file named in the prompt keeps
+ * relevance 100 even if it is also a keyword hit.
+ */
+export function mergeCandidates({ mentioned = [], changed = [], historic = [], keywordHits = [] }) {
+  const seen = new Set();
+  const items = [];
+  const add = (file, reason, relevance) => {
+    if (seen.has(file) || shouldSkipFile(file)) return;
+    seen.add(file);
+    items.push({ file, reason, relevance });
+  };
+
+  for (const f of mentioned) add(f, 'mentioned in prompt', 100);
+  for (const f of changed) add(f, 'modified in git working tree', 85);
+  for (const h of historic) {
+    add(h.file, `historically useful (edited in ${h.edits}/${h.sessions} sessions)`,
+      Math.round(70 * h.confidence));
+  }
+  for (const k of keywordHits) {
+    add(k.file, `matches task keywords (score ${k.score})`, 30 + Math.min(40, k.score * 3));
+  }
+  return items;
+}
+
+/**
+ * Take files off the ranked list until the next one would break the cap.
+ * Stops rather than skips: the list is relevance-sorted, so continuing past a
+ * big file would trade a more relevant file for a less relevant one.
+ * `minFiles` wins over the cap — a pack of one file helps nobody.
+ */
+export function applyBudgetCap(items, cap, minFiles = 3) {
+  const files = [];
+  let totalTokens = 0;
+  for (const it of items) {
+    if (totalTokens + it.tokens > cap && files.length >= minFiles) break;
+    files.push(it);
+    totalTokens += it.tokens;
+  }
+  // cap is 0 when packBudgetPercent is configured to 0 (#39). Dividing by it
+  // printed NaN%; a percentage of nothing is not a number we can defend.
+  const capUsedPercent = cap > 0 ? Math.round((totalTokens / cap) * 100) : null;
+  return { files, totalTokens, capUsedPercent };
+}
+
 // ── Main composition ─────────────────────────────────────────────────────────
 
 export function buildPack(task, cwd) {
@@ -180,38 +255,7 @@ export function buildPack(task, cwd) {
   const historic = findHistoricallyUseful(cwd, 6);
   const keywordHits = findFilesByKeywords(cwd, keywords, 10);
 
-  // Merge with priorities: mentioned > changed > historic > keyword
-  const seen = new Set();
-  const items = [];
-
-  for (const f of mentioned) {
-    if (seen.has(f) || shouldSkipFile(f)) continue;
-    seen.add(f);
-    items.push({ file: f, reason: 'mentioned in prompt', relevance: 100 });
-  }
-  for (const f of changed) {
-    if (seen.has(f) || shouldSkipFile(f)) continue;
-    seen.add(f);
-    items.push({ file: f, reason: 'modified in git working tree', relevance: 85 });
-  }
-  for (const h of historic) {
-    if (seen.has(h.file)) continue;
-    seen.add(h.file);
-    items.push({
-      file: h.file,
-      reason: `historically useful (edited in ${h.edits}/${h.sessions} sessions)`,
-      relevance: Math.round(70 * h.confidence),
-    });
-  }
-  for (const k of keywordHits) {
-    if (seen.has(k.file)) continue;
-    seen.add(k.file);
-    items.push({
-      file: k.file,
-      reason: `matches task keywords (score ${k.score})`,
-      relevance: 30 + Math.min(40, k.score * 3),
-    });
-  }
+  const items = mergeCandidates({ mentioned, changed, historic, keywordHits });
 
   // For each item, suggest a range and estimate tokens.
   const enriched = items.map(it => {
@@ -228,22 +272,16 @@ export function buildPack(task, cwd) {
   const config = loadConfig();
   const budget = getEffectiveBudget(config);
   const cap = Math.round(budget * (getThresholds().packBudgetPercent / 100));
-  let running = 0;
-  const final = [];
-  for (const it of enriched) {
-    if (running + it.tokens > cap && final.length >= 3) break;
-    final.push(it);
-    running += it.tokens;
-  }
+  const { files, totalTokens, capUsedPercent } = applyBudgetCap(enriched, cap);
 
   return {
     task,
     cwd,
     keywords,
-    files: final,
-    totalEstTokens: running,
+    files,
+    totalEstTokens: totalTokens,
     budget,
-    capUsedPercent: Math.round((running / cap) * 100),
+    capUsedPercent,
   };
 }
 
@@ -256,7 +294,8 @@ function formatPack(pack, asJson) {
   out.push('  ' + '─'.repeat(70));
   out.push(`  Task: ${pack.task ? pack.task.slice(0, 80) : '(none — using git state)'}`);
   out.push(`  Files proposed: ${pack.files.length}`);
-  out.push(`  Est. tokens: ${formatTokens(pack.totalEstTokens)} (${pack.capUsedPercent}% of context budget cap)`);
+  out.push(`  Est. tokens: ${formatTokens(pack.totalEstTokens)}` +
+    (pack.capUsedPercent === null ? ' (no budget cap configured)' : ` (${pack.capUsedPercent}% of context budget cap)`));
   if (pack.keywords.length > 0) out.push(`  Keywords: ${pack.keywords.join(', ')}`);
   out.push('');
   out.push('  Read these in order:');

--- a/tests/test.js
+++ b/tests/test.js
@@ -2418,3 +2418,116 @@ describe('pattern sharing: imported data never overrides local evidence', () => 
     assert.equal(importedVerdict({ fileFrequency: {}, wastedReads: {} }, '/p/a.ts', ROOT), null);
   });
 });
+
+// ── smart-pack: the logic that decides what reaches the context ─────────────
+// /cco-pack proposes files for Claude to read. Nothing here was under test, so
+// a scoping bug could recommend another project's source and no one would know.
+
+describe('smart-pack: path scoping', () => {
+  it('isInside respects path boundaries, not string prefixes', async () => {
+    const { isInside } = await import('../src/smart-pack.js');
+    assert.equal(isInside('/a/b/src/x.js', '/a/b'), true);
+    assert.equal(isInside('/a/b', '/a/b'), true);          // the root itself
+    assert.equal(isInside('/a/bc/x.js', '/a/b'), false);   // sibling, not child
+    assert.equal(isInside('/a/b/x.js', '/a/b/'), true);    // trailing slash
+    assert.equal(isInside('/other/x.js', '/a/b'), false);
+    assert.equal(isInside('', '/a/b'), false);
+    assert.equal(isInside('/a/b/x.js', ''), false);
+  });
+
+  it('isInside normalizes Windows separators', async () => {
+    const { isInside } = await import('../src/smart-pack.js');
+    assert.equal(isInside('C:\\proj\\src\\a.ts', 'C:\\proj'), true);
+    assert.equal(isInside('C:\\projX\\src\\a.ts', 'C:\\proj'), false);
+  });
+
+  it('projectScope picks the longest tracked root owning cwd', async () => {
+    const { projectScope } = await import('../src/smart-pack.js');
+    const keys = ['_global', '/repos', '/repos/app', '/elsewhere'];
+    assert.equal(projectScope('/repos/app/src', keys), '/repos/app'); // most specific
+    assert.equal(projectScope('/repos/other', keys), '/repos');
+    assert.equal(projectScope('/nowhere', keys), '/nowhere');         // falls back to cwd
+    assert.equal(projectScope('/x', ['_global']), '/x');              // never _global
+  });
+});
+
+describe('smart-pack: candidate merge', () => {
+  it('first source to claim a path owns its relevance', async () => {
+    const { mergeCandidates } = await import('../src/smart-pack.js');
+    const items = mergeCandidates({
+      mentioned: ['/p/a.js'],
+      changed: ['/p/a.js', '/p/b.js'],                                  // a.js already claimed
+      historic: [{ file: '/p/c.js', confidence: 0.5, edits: 2, sessions: 4 }],
+      keywordHits: [{ file: '/p/b.js', score: 9 }, { file: '/p/d.js', score: 2 }],
+    });
+    assert.deepEqual(items.map(i => i.file), ['/p/a.js', '/p/b.js', '/p/c.js', '/p/d.js']);
+    assert.equal(items[0].relevance, 100);                              // mentioned wins
+    assert.equal(items[1].relevance, 85);                               // changed, not keyword
+    assert.equal(items[2].relevance, 35);                               // round(70 * 0.5)
+    assert.equal(items[3].relevance, 36);                               // 30 + min(40, 2*3)
+  });
+
+  it('keyword relevance is capped so it can never outrank a changed file', async () => {
+    const { mergeCandidates } = await import('../src/smart-pack.js');
+    const [only] = mergeCandidates({ keywordHits: [{ file: '/p/a.js', score: 10_000 }] });
+    assert.equal(only.relevance, 70);                                   // 30 + 40, not 30030
+  });
+
+  it('drops files nothing should ever read', async () => {
+    const { mergeCandidates } = await import('../src/smart-pack.js');
+    const items = mergeCandidates({
+      mentioned: ['/p/logo.png', '/p/bundle.min.js', '/p/real.js'],
+      historic: [{ file: '/p/package-lock.json', confidence: 1, edits: 9, sessions: 9 }],
+    });
+    assert.deepEqual(items.map(i => i.file), ['/p/real.js']);
+  });
+});
+
+describe('smart-pack: budget cap', () => {
+  const items = n => Array.from({ length: n }, (_, i) => ({ file: `/p/${i}.js`, tokens: 100 }));
+
+  it('stops before breaking the cap', async () => {
+    const { applyBudgetCap } = await import('../src/smart-pack.js');
+    const { files, totalTokens, capUsedPercent } = applyBudgetCap(items(10), 450);
+    assert.equal(files.length, 4);          // 4*100=400 fits, 500 would not
+    assert.equal(totalTokens, 400);
+    assert.equal(capUsedPercent, 89);
+  });
+
+  it('always returns a usable pack even when the cap is tiny', async () => {
+    const { applyBudgetCap } = await import('../src/smart-pack.js');
+    const { files } = applyBudgetCap(items(10), 1);
+    assert.equal(files.length, 3);          // minFiles beats the cap
+  });
+
+  it('reports no percentage rather than NaN when the cap is zero', async () => {
+    const { applyBudgetCap } = await import('../src/smart-pack.js');
+    const { files, capUsedPercent } = applyBudgetCap(items(10), 0);
+    assert.equal(capUsedPercent, null);     // not NaN, not Infinity
+    assert.equal(files.length, 3);
+  });
+
+  it('one oversized file does not swallow the whole pack', async () => {
+    const { applyBudgetCap } = await import('../src/smart-pack.js');
+    const { files, totalTokens } = applyBudgetCap(
+      [{ file: '/p/huge.js', tokens: 999_999 }, ...items(5)], 450);
+    assert.equal(files.length, 3);          // huge one still counted, minFiles honoured
+    assert.ok(totalTokens > 999_999);
+  });
+});
+
+describe('smart-pack: keyword extraction', () => {
+  it('keeps meaningful terms and drops filler', async () => {
+    const { extractKeywords } = await import('../src/smart-pack.js');
+    const kw = extractKeywords('Please fix the bug in the authentication middleware');
+    assert.ok(kw.includes('authentication'));
+    assert.ok(kw.includes('middleware'));
+    for (const filler of ['please', 'fix', 'bug', 'the']) assert.ok(!kw.includes(filler));
+  });
+
+  it('returns nothing for an empty task instead of throwing', async () => {
+    const { extractKeywords } = await import('../src/smart-pack.js');
+    assert.deepEqual(extractKeywords(''), []);
+    assert.deepEqual(extractKeywords(undefined), []);
+  });
+});


### PR DESCRIPTION
`/cco-pack` proposes the files Claude should read next — and `src/smart-pack.js` had zero tests. Extracting the pure decisions to make them testable surfaced two real defects.

## 1. It could propose another project's source

`findHistoricallyUseful()` folds in the `_global` patterns bucket unconditionally:

```js
if (projKey !== '_global' && !cwd.startsWith(projKey)) continue;
```

`_global` spans **every project on the machine** and stores absolute paths. A file from an unrelated repo exists on disk, so `existsSync` passes, and nothing else looks at where it lives. Measured against real `patterns.json` in this repo:

```
candidates before scope filter: 98
candidates after  scope filter: 34
foreign files now excluded: 64
   x ~/.claude/projects/-Users-...-Engine3-0/memory/MEMORY.md
   x ~/Downloads/GameDev/KEYFRAME_ANIMATION_PLAN.md
```

One of them (`~/Downloads/claude/solbot/config.py`, a different project entirely) ranked **8th by confidence — above most of this repo's own files**. It stayed out of today's pack only because `findHistoricallyUseful(cwd, 6)` takes the top 6 and this project happened to fill them. In a project with fewer tracked files, it ships.

Candidates are now filtered to the tracked root that owns `cwd`.

## 2. Sibling projects matched each other

`cwd.startsWith(projKey)` is a string test, so `/a/bc` counted as inside `/a/b`. `isInside()` compares path segments and normalizes Windows separators (this repo already fixed Windows paths once, in #46).

## 3. `NaN%`

`capUsedPercent: Math.round((running / cap) * 100)` — `cap` is `0` whenever `packBudgetPercent` is configured to `0`, which #39 made user-configurable. The report printed `NaN% of context budget cap`. It now prints `(no budget cap configured)` — this repo has fixed `$NaN` output twice already (#29, #31).

## Tests

Extracts `isInside`, `projectScope`, `mergeCandidates`, `applyBudgetCap` and `extractKeywords` as pure exports. 12 new tests cover:

- path-boundary containment, including the sibling case and Windows separators
- longest-root scope resolution, and that `_global` is never chosen as a scope
- source priority (a file named in the prompt keeps relevance 100 even when it is also a keyword hit)
- the keyword relevance cap — score 10,000 yields 70, not 30,030
- skip-list filtering applied uniformly (it previously skipped the historic and keyword branches)
- cap arithmetic, `minFiles` beating a tiny cap, one oversized file not swallowing the pack, and the zero-cap path returning `null` rather than `NaN`

275 → 287 tests, all passing. `/cco-pack` CLI output verified unchanged on a real query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)